### PR TITLE
Make srpmutil compile with newer rpm library.

### DIFF
--- a/srpmutil/srpmutil.c
+++ b/srpmutil/srpmutil.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#define _RPM_4_4_COMPAT
 #include <rpm/rpmlib.h>
 #include <rpm/rpmbuild.h>
 
@@ -8,16 +9,13 @@ int main(int argc, char * argv[]) {
   rpmts ts = rpmtsCreate();
   char *specfile = argv[1];
   char *targetarch=NULL;
-  void *pointer;
-  int_32 data_size;
-  int_32 type;
-  int ret=0;
   Spec spec;
   Package pkg;
   const char *errorString;
   int noarch=0;
   int fst=0;
-  const char *name, *version, *release, *epoch, *arch;
+  const char *name, *version, *release, *arch;
+  uint32_t *epoch;
 
   if(argc>2) {
 	targetarch=argv[3];


### PR DESCRIPTION
Define _RPM_4_4_COMPAT in order to get some old types and declaration.
Change epoch from char\* to uint32_t.
Remove some unused variables.

Signed-off-by: Frediano Ziglio frediano.ziglio@citrix.com
