### PR TITLE
Make srpmutil compile with newer rpm library.

### DIFF
--- a/srpmutil/srpmutil.c
+++ b/srpmutil/srpmutil.c
@@ -1,5 +1,6 @@
 #include <stdio.h>
 #include <stdlib.h>
+#define _RPM_4_4_COMPAT
 #include <rpm/rpmlib.h>
 #include <rpm/rpmbuild.h>
 
@@ -8,10 +9,6 @@ int main(int argc, char * argv[]) {
   rpmts ts = rpmtsCreate();
   char *specfile = argv[1];
   char *targetarch=NULL;
-  void *pointer;
-  int_32 data_size;
-  int_32 type;
-  int ret=0;
   Spec spec;
   Package pkg;
   const char *errorString;


### PR DESCRIPTION
Define _RPM_4_4_COMPAT in order to get some old types and declaration.
Remove some unused variables.

Signed-off-by: Frediano Ziglio frediano.ziglio@citrix.com
## 

This version was tested with different branches and CentOS versions (5.7 and 6.4).
