### PR TITLE
Change configuration to use python 2.6

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,3 +2,5 @@ pylint
 coverage
 nose
 mock
+argparse
+fs

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -57,10 +57,8 @@ class TestArgParsing(unittest.TestCase):
         self.assertEquals('ddir', args.dest_dir)
 
     def test_incorrect_call(self):
-        with self.assertRaises(SystemExit) as ctx:
-            args = install.parse_args_or_exit(['cdir'])
-
-        self.assertEquals(2, ctx.exception.code)
+        self.assertRaises(
+            SystemExit, lambda: install.parse_args_or_exit(['cdir']))
 
 
 class TestRPM(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,11 @@
 [tox]
-envlist=py27
+envlist=py26
 
 [testenv]
 sitepackages=True
+setenv=
+    PIP_ALLOW_UNVERIFIED=fs
+    PIP_ALLOW_ALL_EXTERNAL=1
 deps=-r{toxinidir}/test-requirements.txt
 commands=
     coverage erase


### PR DESCRIPTION
As CentOS 6.4 is still using python 2.6, some updates are required.
