### PR TITLE
Add EPEL dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,9 @@ sudo apt-get -qy install python-rpm rpm
  * Basic dependencies:
 
 ```bash
-yum -y install git rpm-python rpm-build
+wget http://dl.fedoraproject.org/pub/epel/6/x86_64/epel-release-6-8.noarch.rpm
+rpm -Uvh epel-release-6-8.noarch.rpm
+yum -y install git rpm-python rpm-build mock
 ```
  * Pip:
 ```bash


### PR DESCRIPTION
As PlanEx needs mock, it needs EPEL. Adding instructions to README on
how to install them.

fixes xenserver/planex#50
