### PR TITLE
Fix python url parsing

### DIFF
--- a/planex/sources.py
+++ b/planex/sources.py
@@ -8,8 +8,22 @@ from planex.util import run
 
 repos_path = "repos"
 
+def register_scheme(scheme):
+    for method in filter(lambda s: s.startswith('uses_'), dir(urlparse)):
+        getattr(urlparse, method).append(scheme)
+
+def fix_urlparse():
+    (scheme, host, path, _, _, fragment) = urlparse.urlparse("git://foo.bar/baz#fragment")
+    if fragment != "fragment":
+	print "Fixing urlparse"
+	register_scheme("git")
+	register_scheme("hg")
+
 class SCM(object):
     def __init__(self, url):
+	# Test whether we need to fix urlparse:
+	fix_urlparse()
+
         (scheme, host, path, _, _, fragment) = urlparse.urlparse(url)
         urlparts = url.split('#')
         repo_url = "%s://%s%s" % (scheme, host, path) # Strip of fragment


### PR DESCRIPTION
It seems the behaviour changes because of something I don't understand

On my ubuntu 13.10 box, I get this:

Python 2.7.5+ (default, Feb 27 2014, 19:37:08)
[GCC 4.8.1] on linux2
Type "help", "copyright", "credits" or "license" for more information.

> > > import urlparse
> > > urlparse.urlparse("git://foo.bar/baz#hello")
> > > ParseResult(scheme='git', netloc='foo.bar', path='/baz', params='', query='', fragment='hello')

On ubuntu 12.04 I get this:

Python 2.7.3 (default, Apr 20 2012, 22:39:59)
[GCC 4.6.3] on linux2
Type "help", "copyright", "credits" or "license" for more information.

> > > import urlparse
> > > urlparse.urlparse("git://foo.bar/baz#hello")
> > > ParseResult(scheme='git', netloc='foo.bar', path='/baz#hello', params='', query='', fragment='')

Note path contains the fragment in one but not in the other.

Fix this by parsing a known uri and patching if necessary.

Signed-off-by: Jon Ludlam jonathan.ludlam@citrix.com
