### PR TITLE
debian/control: Add runtime dependency on python-setuptools

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,6 +7,6 @@ Standards-Version: 3.9.1
 
 Package: python-planex
 Architecture: all
-Depends: ${misc:Depends}, ${python:Depends}, yum (>= 3.4)
+Depends: ${misc:Depends}, ${python:Depends}, yum (>= 3.4), python-setuptools (>= 0.6b3)
 Description: UNKNOWN
 


### PR DESCRIPTION
Signed-off-by: Euan Harris <euan.harris@citrix.com>