### PR TITLE
Makefile.rules: Clean the SRPMS symlink

### DIFF
--- a/planex/Makefile.rules
+++ b/planex/Makefile.rules
@@ -47,7 +47,7 @@ all: $(TOPDIR) rpms
 
 .PHONY: clean
 clean:
-	rm -rf $(TOPDIR) RPMS
+	rm -rf $(TOPDIR) SRPMS RPMS
 
 
 .DELETE_ON_ERROR: $(TOPDIR)


### PR DESCRIPTION
We now create a symlink from SRPMS to _build/SRPMS.   The
clean target should remove it.

Signed-off-by: Euan Harris <euan.harris@citrix.com>