### PR TITLE
Makefile.rules: Disable planex-cache by default

### DIFF
--- a/planex/Makefile.rules
+++ b/planex/Makefile.rules
@@ -24,7 +24,7 @@ RPMBUILD_FLAGS ?= --quiet --define "_topdir $(TOPDIR)" \
 CREATEREPO ?= createrepo
 CREATEREPO_FLAGS ?= --quiet --update
 
-MOCK ?= planex-cache
+MOCK ?= mock
 MOCK_FLAGS ?= --configdir=$(TOPDIR)/mock --quiet \
               --resultdir=$(dir $@) --uniqueext=$(notdir $@) \
               --disable-plugin=package_state


### PR DESCRIPTION
There is an undiagnosed race between createrepo and planex-cache
in concurrent builds.   Ordinary mock is not affected.

Signed-off-by: Euan Harris <euan.harris@citrix.com>