### PR TITLE
cache: Don't re-use yum's cachedir in /tmp - causes clashes between concurrent jobs

### DIFF
--- a/planex/cache.py
+++ b/planex/cache.py
@@ -69,7 +69,7 @@ def setup_yumbase(yumbase, loopback_repo):
     yumbase.repos.disableRepo('*')
     yumbase.repos.enableRepo(loopback_repo)
 
-    yumbase.setCacheDir(force=True, reuse=True)
+    yumbase.setCacheDir(force=True, reuse=False)
     yumbase.repos.populateSack(cacheonly=True)
 
 


### PR DESCRIPTION
Fixes #150 