### PR TITLE
depend: Don't generate the 'install' target, which is only relevant for ...

### DIFF
--- a/planex/depend.py
+++ b/planex/depend.py
@@ -223,8 +223,6 @@ def main():
     print ""
     print "srpms: " + " \\\n\t".join(all_srpms)
     print ""
-    print "install: all"
-    print "\t. scripts/%s/install.sh" % build_type()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
...buildroot

Signed-off-by: Euan Harris <euan.harris@citrix.com>