### PR TITLE
cache: Print mock's logs if it fails

### DIFF
--- a/planex/cache.py
+++ b/planex/cache.py
@@ -186,7 +186,10 @@ def build_package(configdir, root, passthrough_args):
            "--root=%s" % root,
            "--resultdir=%s" % working_directory] + passthrough_args
 
-    util.run(cmd)
+    logfiles = [os.path.join(working_directory, "root.log"),
+                os.path.join(working_directory, "build.log")]
+    util.run(cmd, logfiles=logfiles)
+
     return working_directory
 
 

--- a/planex/util.py
+++ b/planex/util.py
@@ -51,12 +51,15 @@ def get_yumbase(config):
     return yumbase
 
 
-def run(cmd, check=True, env=None, inputtext=None):
+def run(cmd, check=True, env=None, inputtext=None, logfiles=None):
     """
     Run a command, dumping it cut-n-pasteably if required. Checks the return
     code unless check=False. Returns a dictionary of stdout, stderr and return
     code (rc)
     """
+    if logfiles is None:
+        logfiles = []
+
     logging.debug("running command: %s",
                   (" ".join([pipes.quote(word) for word in cmd])))
 
@@ -72,6 +75,9 @@ def run(cmd, check=True, env=None, inputtext=None):
                       (" ".join([pipes.quote(word) for word in cmd])))
         logging.error("stdout: %s", stdout)
         logging.error("stderr: %s", stderr)
+        for log_path in logfiles:
+            with open(log_path) as log_file:
+                logging.error("%s:\n%s", log_path, log_file.read())
         raise Exception
 
     return {"stdout": stdout, "stderr": stderr, "rc": proc.returncode}


### PR DESCRIPTION
We print mock's stderr and stdout if it fails, but the most useful
information for debugging a mock failure is often in the root.log
and build.log files.    Print these as well.

Signed-off-by: Euan Harris <euan.harris@citrix.com>