### PR TITLE
Depend on yum-plugin-priorities

### DIFF
--- a/planex.spec
+++ b/planex.spec
@@ -7,12 +7,12 @@ Source0: http://github.com/xenserver/planex/archive/v%{version}/%{name}-%{versio
 License: LGPLv2.1
 BuildArch: noarch
 BuildRequires: python-setuptools
-Requires: mock
-Requires: rpm-build
 Requires: createrepo
-Requires: python-argparse
+Requires: mock
 Requires: python-argcomplete
+Requires: python-argparse
 Requires: python-setuptools
+Requires: rpm-build
 
 %description
 Planex is a tool for building RPMs and deb files. It manages interdependencies

--- a/planex.spec
+++ b/planex.spec
@@ -13,6 +13,7 @@ Requires: python-argcomplete
 Requires: python-argparse
 Requires: python-setuptools
 Requires: rpm-build
+Requires: yum-plugin-priorities
 
 %description
 Planex is a tool for building RPMs and deb files. It manages interdependencies


### PR DESCRIPTION
We set the priority of the loopback repository such that it overrides the base system repository.  Without this plugin, priority assignments in yum.conf.d are ignored.