### PR TITLE
CA-193900: Revert "CA-193263: Install openssl-xs/-wrapper RPMs into mock repo"

### DIFF
--- a/mk/Makefile
+++ b/mk/Makefile
@@ -22,9 +22,6 @@ buildrpms: conf_dir srpmutil
 	rm -rf planex-build-root/RPMS
 	mkdir planex-build-root/RPMS
 	cp /distfiles/centos5/buildsys-build* planex-build-root/RPMS
-	cp /output/openssl-xs/RPMS/x86_64/*.rpm planex-build-root/RPMS
-	cp /output/openssl-xs/RPMS/noarch/*.rpm planex-build-root/RPMS
-	cp /output/openssl-wrapper/RPMS/x86_64/*.rpm planex-build-root/RPMS
 	createrepo planex-build-root/RPMS/
 	touch /etc/hosts
 	planex-build --xs-build-sys --use-mock


### PR DESCRIPTION
This reverts commit 69479653ef0fd1ed9e887753012e84e8297a31a7.

Signed-off-by: Phus Lu <phus.lu@citrix.com>