### PR TITLE
Move Emacs mode line to top of file

### DIFF
--- a/planex/Makefile.rules
+++ b/planex/Makefile.rules
@@ -1,3 +1,4 @@
+# -*- MakeFile -*-
 ############################################################################
 # Configuration variables
 ############################################################################
@@ -169,4 +170,3 @@ $(DEPS): $(TOPDIR) SPECS/*.spec $(wildcard $(PINSFILE) $(PINDEPS) $(PINSDIR)/*.s
 -include $(DEPS)
 
 # vim:ft=make:
-# -*- MakeFile -*-


### PR DESCRIPTION
Major mode is determined from the first non-blank line, see
https://www.gnu.org/software/emacs/manual/html_node/emacs/Choosing-Modes.html