### PR TITLE
cache: Make sure we call /usr/bin/mock instead of /usr/sbin/mock

### DIFF
--- a/planex/cache.py
+++ b/planex/cache.py
@@ -197,7 +197,7 @@ def build_package(configdir, root, passthrough_args):
     working_directory = tempfile.mkdtemp(prefix="planex-cache")
     logging.debug("Mock working directory: %s", working_directory)
 
-    cmd = ["mock", "--configdir=%s" % configdir,
+    cmd = ["/usr/bin/mock", "--configdir=%s" % configdir,
            "--root=%s" % root,
            "--resultdir=%s" % working_directory] + passthrough_args
 


### PR DESCRIPTION
Mock should be run by a normal user account calling /usr/bin/mock.
If the user's path causes /usr/sbin/mock to be picked up instead,
it will exit with a warning but with a 0 exit code.
Subprocess.Popen will not detect this as an error and the build will
appear to succeed without building anything.

Signed-off-by: Euan Harris <euan.harris@citrix.com>