### PR TITLE
packaging: Do not install Bash completion file through setuptools

### DIFF
--- a/planex.spec
+++ b/planex.spec
@@ -29,6 +29,7 @@ sed -i "s/\(version='\)[^'\"]\+/\1%{version}-%{release}/g" setup.py
 
 %install
 %{__python} setup.py install --single-version-externally-managed -O1 --root=$RPM_BUILD_ROOT --record=INSTALLED_FILES
+%{__install} -D -m 644 planex/planex.bash %{buildroot}%{_sysconfdir}/bash_completion.d/planex.bash
 
 %files
 %doc README.md

--- a/setup.py
+++ b/setup.py
@@ -9,8 +9,7 @@ setup(name='planex',
       packages=['planex'],
       include_package_data=True,
       package_data={'planex': ['Makefile.rules']},
-      data_files=[('/usr/share/planex', ['planex/Makefile.rules']),
-                  ('/etc/bash_completion.d/', ['planex/planex.bash'])],
+      data_files=[('/usr/share/planex', ['planex/Makefile.rules'])],
       entry_points={
           'console_scripts': [
               'planex-init = planex.init:main',


### PR DESCRIPTION
Installing files to /etc in setup.py breaks virtualenv

Signed-off-by: Euan Harris <euan.harris@citrix.com>