### PR TITLE
Allow multiple pins from single repo

### DIFF
--- a/planex/pin.py
+++ b/planex/pin.py
@@ -183,8 +183,9 @@ def update(args):
 
             tmpdir = tempfile.mkdtemp(prefix='planex-pin')
             tmp_archive = archive(repo, treeish, orig_version, tmpdir)
-            tar_name = os.path.basename(tmp_archive).replace(orig_version,
-                                                             src_version)
+            tar_name = os.path.basename(tmp_archive)
+            tar_name = tar_name.replace(orig_version,
+                                        orig_version+'-'+src_version)
             tar_path = os.path.join(args.pins_dir, tar_name)
             maybe_copy(tmp_archive, tar_path, args.force)
             shutil.rmtree(tmpdir)


### PR DESCRIPTION
Currently we cannot handle below pin file
```
{
  "SPECS/citrix-wlb.spec": {
    "0": "../wlb#master"
  },
  "SPECS/oem-wlb.spec": {
    "0": "../wlb#master"
  }
}
```
planex-pin will generate a single source tabball (i.e. _build/PINS/wlb-revision.tar.gz)
This behavior will cause `%setup -q -n wlb-%{version}` failure.

This patch adds origin_version as the prefix to generate different sources tarballs.