### PR TITLE
makesrpm: handle sources with no top-level directory

### DIFF
--- a/planex/makesrpm.py
+++ b/planex/makesrpm.py
@@ -94,7 +94,10 @@ def extract_topdir(tmp_specfile, source):
         if 'autosetup' in line:
             tar = tarfile.open(source)
             topname = os.path.commonprefix(tar.getnames())
-            print "%s -n %s" % (line.strip(), topname)
+            if topname:
+                print "%s -n %s" % (line.strip(), topname)
+            else:
+                print "%s -c" % line.strip()
         else:
             print line,
 


### PR DESCRIPTION
Bitbucket generates source archives without a directory, adjust
%autosetup accordingly.

Signed-off-by: Simon Rowe <simon.rowe@eu.citrix.com>