### PR TITLE
makesrpm: add initial support for patch guards

### DIFF
--- a/tests/test_makesrpm.py
+++ b/tests/test_makesrpm.py
@@ -1,0 +1,29 @@
+# Run these tests with 'nosetests':
+#   install the 'python-nose' package (Fedora/CentOS or Ubuntu)
+#   run 'nosetests' in the root of the repository
+
+import glob
+import os
+import sys
+import unittest
+
+import planex.makesrpm
+
+
+class BasicTests(unittest.TestCase):
+    # unittest.TestCase has more methods than Pylint permits
+    # pylint: disable=R0904
+
+    def test_patch_guards(self):
+        series = ("patch_no_guard_or_comment\n",
+                  "patch_with_a_comment # this is a comment\n",
+                  "patch_with_a_positive_guard #+aguard\n",
+                  "patch_with_a_negative_guard #-aguard\n",
+                  )
+
+        applied = list(planex.makesrpm.parse_patchseries(series))
+
+        self.assertIn("patch_no_guard_or_comment", applied)
+        self.assertIn("patch_with_a_comment", applied)
+        self.assertNotIn("patch_with_a_positive_guard", applied)
+        self.assertIn("patch_with_a_negative_guard", applied)


### PR DESCRIPTION
Add a guard parameter to parse_patchseries() and use it to select
guarded patches. No caller defines it yet so it causes no positive
guards and all negative guards to be applied.

Signed-off-by: Simon Rowe <simon.rowe@eu.citrix.com>