### PR TITLE
depend: add Emacs and vim mode line

### DIFF
--- a/planex/depend.py
+++ b/planex/depend.py
@@ -123,6 +123,8 @@ def main():
     args = parse_cmdline()
     specs = {}
 
+    print "# -*- makefile -*-"
+    print "# vim:ft=make:"
     pkgs_to_ignore = args.ignore
     for ignore_from in args.ignore_from:
         try:


### PR DESCRIPTION
The dependency recipes are more readable if editors are informed that
the content of the file is a Makefile.

Signed-off-by: Simon Rowe <simon.rowe@eu.citrix.com>