### PR TITLE
Generate dependencies from $(TOPDIR)/SPECS

### DIFF
--- a/planex/Makefile.rules
+++ b/planex/Makefile.rules
@@ -135,9 +135,9 @@ $(PINDEPS): $(PINSFILE)
 # If dependency generation fails, the deps file is deleted to avoid
 # problems with empty, incomplete or corrupt deps.   
 .DELETE_ON_ERROR: $(DEPS)
-$(DEPS): $(TOPDIR) SPECS/*.spec $(wildcard $(PINSFILE) $(PINDEPS) $(PINSDIR)/*.spec)
+$(DEPS): $(TOPDIR) $(wildcard $(TOPDIR)/SPECS/*.spec $(PINSFILE) $(PINDEPS) $(PINSDIR)/*.spec)
 	@echo Updating dependencies...
-	$(AT)$(DEPEND) $(DEPEND_FLAGS) SPECS/*.spec > $@
+	$(AT)$(DEPEND) $(DEPEND_FLAGS) $(TOPDIR)/SPECS/*.spec > $@
 
 -include $(DEPS)
 


### PR DESCRIPTION
Make the dependency rules refer to $(TOPDIR)/SPECS rather than SPECS,
at present the directories are symlinked but this will cope with
$(TOPDIR)/SPECS containing links and/or real specfiles.

Signed-off-by: Simon Rowe <simon.rowe@eu.citrix.com>