### PR TITLE
extract: prefix patches with package name

### DIFF
--- a/planex/extract.py
+++ b/planex/extract.py
@@ -68,7 +68,8 @@ def rewrite_spec(spec_in, spec_out, patches, patchnum):
                 if not done and line.upper().startswith('SOURCE'):
                     for patch in patches:
                         patchnum += 1
-                        fh_out.write("Patch%d: %s\n" % (patchnum, patch))
+                        fh_out.write("Patch%d: %%{name}-%s\n" %
+                                     (patchnum, patch))
                     done = True
                 fh_out.write(line)
 
@@ -159,7 +160,13 @@ def main(argv):
                                 check_package_name=args.check_package_names)
         for path, url in spec.all_sources():
             if url.netloc == '':
-                src_path = os.path.join(patch_dir, url.path)
+                if 'patchqueue' in link:
+                    # trim off prefix
+                    src_path = os.path.join(patch_dir,
+                                            url.path[len(spec.name()) + 1:])
+                else:
+                    src_path = os.path.join(patch_dir, url.path)
+
                 if src_path not in tar.getnames():
                     src_path = os.path.join(tar_root, url.path)
                 extract_file(tar, src_path, path)

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -47,6 +47,6 @@ class BasicTests(unittest.TestCase):
         with open(outfile) as fh:
             spec = fh.read(4096).split('\n')
 
-        self.assertIn("Patch0: first.patch", spec)
-        self.assertIn("Patch1: second.patch", spec)
-        self.assertIn("Patch2: third.patch", spec)
+        self.assertIn("Patch0: %{name}-first.patch", spec)
+        self.assertIn("Patch1: %{name}-second.patch", spec)
+        self.assertIn("Patch2: %{name}-third.patch", spec)


### PR DESCRIPTION
Patches many not be named uniquely and are all currently written to
SOURCES. Add a prefix to disambiguate them.

Signed-off-by: Simon Rowe <simon.rowe@eu.citrix.com>