### PR TITLE
Correctly return the name of the top level directory of the tarball

### DIFF
--- a/planex/extract.py
+++ b/planex/extract.py
@@ -98,7 +98,7 @@ def archive_root(tar):
     """
     Return the name of the top level directory of the tarball
     """
-    if tar.firstmember.type == tarfile.DIRTYPE:
+    if len(tar.members) == 1 and tar.members[0].isdir():
         return tar.firstmember.name
     return ''
 

--- a/planex/extract.py
+++ b/planex/extract.py
@@ -98,6 +98,7 @@ def archive_root(tar):
     """
     Return the name of the top level directory of the tarball
     """
+    _ = tar.getnames()
     if len(tar.members) == 1 and tar.members[0].isdir():
         return tar.firstmember.name
     return ''

--- a/planex/makesrpm.py
+++ b/planex/makesrpm.py
@@ -59,8 +59,8 @@ def extract_topdir(tmp_specfile, source):
     for line in fileinput.input(tmp_specfile, inplace=True):
         if 'autosetup' in line:
             tar = tarfile.open(source)
-            topname = os.path.commonprefix(tar.getnames())
-            if topname:
+            if len(tar.members) == 1 and tar.members[0].isdir():
+                topname = os.path.commonprefix(tar.getnames())
                 print "%s -n %s" % (line.strip(), topname)
             else:
                 print "%s -c" % line.strip()

--- a/planex/makesrpm.py
+++ b/planex/makesrpm.py
@@ -59,6 +59,7 @@ def extract_topdir(tmp_specfile, source):
     for line in fileinput.input(tmp_specfile, inplace=True):
         if 'autosetup' in line:
             tar = tarfile.open(source)
+            _ = tar.getnames()
             if len(tar.members) == 1 and tar.members[0].isdir():
                 topname = os.path.commonprefix(tar.getnames())
                 print "%s -n %s" % (line.strip(), topname)


### PR DESCRIPTION
makesrpm.py: when no topdir is present in the tarball, a simple 'os.path.commonprefix' would fail if all the files start with a common pattern.

extract.py: there can be multiple directories inside the tarball. It is wrong to simply assume that the first one of them is a topdir. This is correct only if there is a single file in the top level of the tarball.