### PR TITLE
Correctly return topdir of tarball

### DIFF
--- a/planex/Makefile.rules
+++ b/planex/Makefile.rules
@@ -76,8 +76,8 @@ $(TOPDIR):
 ############################################################################
 
 # Fetch a source tarball listed in a spec file.
-.DELETE_ON_ERROR: %.tar %.tar.gz %.tar.bz2 %.tgz %.tbz %.zip %.pdf
-%.tar %.tar.gz %.tar.bz2 %.tgz %.tbz %.zip %.pdf:
+.DELETE_ON_ERROR: %.tar %.tar.gz %.tar.xz %.tar.bz2 %.tgz %.tbz %.zip %.pdf
+%.tar %.tar.gz %.tar.xz %.tar.bz2 %.tgz %.tbz %.zip %.pdf:
 	@echo [FETCH] $@
 	$(AT)$(FETCH) $(FETCH_FLAGS) $< $@
 

--- a/planex/extract.py
+++ b/planex/extract.py
@@ -98,8 +98,11 @@ def archive_root(tar):
     """
     Return the name of the top level directory of the tarball
     """
-    if tar.firstmember.type == tarfile.DIRTYPE:
-        return tar.firstmember.name
+    topname = os.path.commonprefix(tar.getnames())
+    if topname in tar.getnames():
+        top_element = tar.getmember(topname)
+        if top_element.isdir():
+            return topname
     return ''
 
 

--- a/planex/extract.py
+++ b/planex/extract.py
@@ -98,8 +98,9 @@ def archive_root(tar):
     """
     Return the name of the top level directory of the tarball
     """
-    topname = os.path.commonprefix(tar.getnames())
-    if topname in tar.getnames():
+    names = tar.getnames()
+    topname = os.path.commonprefix(names)
+    if topname in names:
         top_element = tar.getmember(topname)
         if top_element.isdir():
             return topname

--- a/planex/fetch.py
+++ b/planex/fetch.py
@@ -26,6 +26,7 @@ SUPPORTED_EXT_TO_MIME = {
     '.tar': 'application/x-tar',
     '.gz': 'application/x-gzip',
     '.tgz': 'application/x-gzip',
+    '.txz': 'application/x-gzip',
     '.bz2': 'application/x-bzip2',
     '.tbz': 'application/x-bzip2',
     '.zip': 'application/zip',

--- a/planex/makesrpm.py
+++ b/planex/makesrpm.py
@@ -59,8 +59,9 @@ def extract_topdir(tmp_specfile, source):
     for line in fileinput.input(tmp_specfile, inplace=True):
         if 'autosetup' in line:
             tar = tarfile.open(source)
-            topname = os.path.commonprefix(tar.getnames())
-            if topname in tar.getnames():
+            names = tar.getnames()
+            topname = os.path.commonprefix(names)
+            if topname in names:
                 top_element = tar.getmember(topname)
                 if top_element.isdir():
                     print "%s -n %s" % (line.strip(), topname)

--- a/planex/makesrpm.py
+++ b/planex/makesrpm.py
@@ -60,8 +60,10 @@ def extract_topdir(tmp_specfile, source):
         if 'autosetup' in line:
             tar = tarfile.open(source)
             topname = os.path.commonprefix(tar.getnames())
-            if topname:
-                print "%s -n %s" % (line.strip(), topname)
+            if topname in tar.getnames():
+                top_element = tar.getmember(topname)
+                if top_element.isdir():
+                    print "%s -n %s" % (line.strip(), topname)
             else:
                 print "%s -c" % line.strip()
         else:


### PR DESCRIPTION
This fix will correctly return the topdir of a tarball (if any). Without this fix the code would return an incorrect result in situations in which all the files in the tarball have a common prefix but they are not stored in any topdir.