### PR TITLE
Per package sourcedirs

### DIFF
--- a/planex/Makefile.rules
+++ b/planex/Makefile.rules
@@ -45,13 +45,13 @@ endif
 # Main targets
 ############################################################################
 
-.PHONY: all rpms srpms srpm_repo
+.PHONY: all rpms
 
 all: $(TOPDIR) rpms
 
 .PHONY: clean
 clean:
-	rm -rf $(TOPDIR) SRPMS RPMS
+	rm -rf $(TOPDIR) RPMS
 
 
 .DELETE_ON_ERROR: $(TOPDIR)
@@ -63,11 +63,8 @@ $(TOPDIR):
 	@ln -s ../SOURCES $(TOPDIR)/SOURCES
 	@ln -s ../mock $(TOPDIR)/mock
 	@mkdir $(TOPDIR)/RPMS
-	@mkdir $(TOPDIR)/SRPMS
 	@ln -s $(TOPDIR)/RPMS RPMS
-	@ln -s $(TOPDIR)/SRPMS SRPMS
 	$(AT)$(CREATEREPO) ${QUIET+--quiet} RPMS
-	$(AT)$(CREATEREPO) ${QUIET+--quiet} SRPMS
 	@echo done
 
 
@@ -108,13 +105,6 @@ $(TOPDIR)/SPECS/%.spec: SPECS/%.lnk SOURCES/%.patches.tar
 %.src.rpm:
 	@echo [RPMBUILD] $@ 
 	$(AT)$(RPMBUILD) $(RPMBUILD_FLAGS) $^
-
-# Phony target to create repository metadata for the SRPMs.   This makes
-# it possible to add the SRPMS directory to yum.conf and use yumdownloader
-# to install source RPMs.
-srpm_repo: srpms
-	@echo [CREATEREPO] SRPMS
-	$(AT)flock --timeout 30 ./$(TOPDIR)/SRPMS $(CREATEREPO) $(CREATEREPO_FLAGS) ./$(TOPDIR)/SRPMS
 
 # Build one or more binary RPMs from a source RPM.   A typical source RPM
 # might produce a base binary RPM, a -devel binary RPM containing library

--- a/planex/Makefile.rules
+++ b/planex/Makefile.rules
@@ -79,8 +79,8 @@ $(TOPDIR):
 	$(AT)$(FETCH) $(FETCH_FLAGS) $< $@
 
 # Fetch a patch tarball listed in a link file.
-.PRECIOUS: SOURCES/%.patches.tar
-SOURCES/%.patches.tar: SPECS/%.lnk
+.PRECIOUS: SOURCES/%/patches.tar
+SOURCES/%/patches.tar: SPECS/%.lnk
 	$(AT)$(FETCH) $(FETCH_FLAGS) $< $@
 
 
@@ -89,7 +89,7 @@ SOURCES/%.patches.tar: SPECS/%.lnk
 ############################################################################
 
 # Extract a spec file from a patch tarball.
-$(TOPDIR)/SPECS/%.spec: SPECS/%.lnk SOURCES/%.patches.tar
+$(TOPDIR)/SPECS/%.spec: SPECS/%.lnk SOURCES/%/patches.tar
 	$(AT)$(EXTRACT) $(EXTRACT_FLAGS) --output $@ --link $^
 
 

--- a/planex/extract.py
+++ b/planex/extract.py
@@ -31,6 +31,7 @@ def extract_file(tar, name_in, name_out):
     mem = tar.getmember(name_in)
     mem.name = os.path.basename(name_out)
     tar.extract(mem, os.path.dirname(name_out))
+    os.utime(name_out, None)
 
 
 def parse_patchseries(series, guard=None):

--- a/planex/makesrpm.py
+++ b/planex/makesrpm.py
@@ -42,11 +42,9 @@ def setup_tmp_area():
     """
     tmp_dirpath = tempfile.mkdtemp()
     tmp_specs = os.path.join(tmp_dirpath, 'SPECS')
-    tmp_build = os.path.join(tmp_dirpath, '_build')
-    tmp_sources = os.path.join(tmp_build, 'SOURCES')
+    tmp_sources = os.path.join(tmp_dirpath, 'SOURCES')
 
     os.makedirs(tmp_specs)
-    os.makedirs(tmp_build)
     os.makedirs(tmp_sources)
 
     return (tmp_dirpath, tmp_specs, tmp_sources)
@@ -113,9 +111,8 @@ def main(argv):
         for source in passthrough_args[1:]:
             if any([ext in source for ext in tarball_filters]):
                 extract_topdir(tmp_specfile, source)
-                copyfile(source, os.path.join(tmp_dirpath, source))
-            else:
-                copyfile(source, os.path.join(tmp_dirpath, source))
+            dest = os.path.join(tmp_sources, os.path.basename(source))
+            copyfile(source, dest)
 
         cmd = get_command_line(intercepted_args, tmp_sources, tmp_specfile)
         return_value = subprocess.call(cmd)

--- a/planex/spec.py
+++ b/planex/spec.py
@@ -29,11 +29,6 @@ def specdir():
     return rpm.expandMacro('%_specdir')
 
 
-def sourcedir():
-    """Return the expanded value of the RPM %_sourcedir macro"""
-    return rpm.expandMacro('%_sourcedir')
-
-
 def flatten(lst):
     """Flatten a list of lists"""
     return sum(lst, [])
@@ -118,8 +113,15 @@ class Spec(object):
         #    http://www.example.com/foo/bar.tar.gz -> bar.tar.gz
         #    http://www.example.com/foo/bar.cgi#/baz.tbz -> baz.tbz
 
-        return [os.path.join(sourcedir(), os.path.basename(url))
-                for url in self.source_urls()]
+        hdr = self.spec.sourceHeader
+        rpm.addMacro('name', hdr['name'])
+        rpm.addMacro('_sourcedir', "%_topdir/SOURCES/%name")
+        paths = [os.path.join(rpm.expandMacro("%_sourcedir"),
+                              os.path.basename(url))
+                 for url in self.source_urls()]
+        rpm.delMacro('_sourcedir')
+        rpm.delMacro('name')
+        return paths
 
     # RPM build dependencies.   The 'requires' key for the *source* RPM is
     # actually the 'buildrequires' key from the spec

--- a/tests/test_depend.py
+++ b/tests/test_depend.py
@@ -25,15 +25,15 @@ class BasicTests(unittest.TestCase):
             sys.stdout.getvalue(),
             "./SRPMS/ocaml-cohttp-0.9.8-1.el6.src.rpm: "
             "tests/data/ocaml-cohttp.spec "
-            "./SOURCES/ocaml-cohttp-0.9.8.tar.gz "
-            "./SOURCES/ocaml-cohttp-init\n")
+            "./SOURCES/ocaml-cohttp/ocaml-cohttp-0.9.8.tar.gz "
+            "./SOURCES/ocaml-cohttp/ocaml-cohttp-init\n")
 
     def test_download_rpm_sources(self):
         planex.depend.download_rpm_sources(self.spec)
 
         self.assertEqual(
             sys.stdout.getvalue(),
-            "./SOURCES/ocaml-cohttp-0.9.8.tar.gz: "
+            "./SOURCES/ocaml-cohttp/ocaml-cohttp-0.9.8.tar.gz: "
             "tests/data/ocaml-cohttp.spec\n")
 
     def test_build_rpm_from_srpm(self):

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -49,8 +49,8 @@ class RpmTests(unittest.TestCase):
     def test_source_paths(self):
         self.assertEqual(
             self.spec.source_paths(),
-            ["./SOURCES/ocaml-cohttp-0.9.8.tar.gz",
-             "./SOURCES/ocaml-cohttp-init"])
+            ["./SOURCES/ocaml-cohttp/ocaml-cohttp-0.9.8.tar.gz",
+             "./SOURCES/ocaml-cohttp/ocaml-cohttp-init"])
 
     def test_buildrequires(self):
         self.assertEqual(


### PR DESCRIPTION
Use per-package directories under SOURCES to store source files.  This removes the risk of name collisions between patches for different packages.