### PR TITLE
spec: silence errors about missing sources

### DIFF
--- a/planex/spec.py
+++ b/planex/spec.py
@@ -63,7 +63,15 @@ class Spec(object):
         rpm.addMacro('dist', dist)
 
         try:
-            self.spec = rpm.ts().parseSpec(path)
+            # silence errors about missing sources
+            with open(os.devnull, "w") as nullfh:
+                errcpy = os.dup(2)
+                try:
+                    os.dup2(nullfh.fileno(), 2)
+                    self.spec = rpm.ts().parseSpec(path)
+                finally:
+                    os.dup2(errcpy, 2)
+                    os.close(errcpy)
         except ValueError as exn:
             exn.args = (exn.args[0].rstrip() + ' ' + path, )
             raise


### PR DESCRIPTION
The rpm bindings complain to stderr that sources do not exist. This is
expected in some use cases, e.g. when generating the dependency file.
Temporarily redirect stderr to /dev/null while parsing the spec file.

Signed-off-by: Simon Rowe <simon.rowe@eu.citrix.com>