### PR TITLE
spec, Makefile.rules: Don't unconditionally override _sourcedir

### DIFF
--- a/planex/Makefile.rules
+++ b/planex/Makefile.rules
@@ -9,6 +9,9 @@ DEPS = $(TOPDIR)/deps
 PINSFILE = pins
 PINDEPS = $(TOPDIR)/pindeps
 PINSDIR = $(TOPDIR)/PINS
+RPM_DEFINES ?= --define="_topdir $(TOPDIR)" \
+               --define="dist $(DIST)" \
+               $(RPM_EXTRA_DEFINES)
 
 
 ############################################################################
@@ -16,13 +19,13 @@ PINSDIR = $(TOPDIR)/PINS
 ############################################################################
 
 FETCH ?= planex-fetch
-FETCH_FLAGS ?= --define="_topdir $(TOPDIR)" $(FETCH_EXTRA_FLAGS)
+FETCH_FLAGS ?= $(RPM_DEFINES) $(FETCH_EXTRA_FLAGS)
 
 EXTRACT ?= planex-extract
-EXTRACT_FLAGS ?= --define="_topdir $(TOPDIR)" $(EXTRACT_EXTRA_FLAGS)
+EXTRACT_FLAGS ?= $(RPM_DEFINES) $(EXTRACT_EXTRA_FLAGS)
 
 RPMBUILD ?= planex-make-srpm
-RPMBUILD_FLAGS ?= ${QUIET+--quiet} --define="_topdir $(TOPDIR)" --define="dist $(DIST)"
+RPMBUILD_FLAGS ?= ${QUIET+--quiet} $(RPM_DEFINES)
 
 CREATEREPO ?= createrepo
 CREATEREPO_FLAGS ?= ${QUIET+--quiet} --update
@@ -34,8 +37,7 @@ MOCK_FLAGS ?= ${QUIET+--quiet} \
               --disable-plugin=package_state
 
 DEPEND ?= planex-depend
-DEPEND_FLAGS ?= --define="dist $(DIST)" --define="_topdir $(TOPDIR)" \
-                --pins-dir $(PINSDIR) $(DEPEND_EXTRA_FLAGS)
+DEPEND_FLAGS ?= $(RPM_DEFINES) --pins-dir $(PINSDIR) $(DEPEND_EXTRA_FLAGS)
 
 ifdef QUIET
 AT = @

--- a/planex/spec.py
+++ b/planex/spec.py
@@ -170,7 +170,6 @@ class Spec(object):
         hdr = self.spec.sourceHeader
         hardcoded_macros = OrderedDict([
             ('name', hdr['name']),
-            ('_sourcedir', "%_topdir/SOURCES/%name")
         ])
 
         # apply custom macros and then append the harcoded overrides

--- a/tests/test_depend.py
+++ b/tests/test_depend.py
@@ -15,9 +15,11 @@ class BasicTests(unittest.TestCase):
     # unittest.TestCase has more methods than Pylint permits
     # pylint: disable=R0904
     def setUp(self):
+        rpm_defines = [("dist", ".el6"),
+                       ("_topdir", "."),
+                       ("_sourcedir", "%_topdir/SOURCES/%name")]
         self.spec = planex.spec.Spec("tests/data/ocaml-cohttp.spec",
-                                     defines=[("dist", ".el6"),
-                                              ("_topdir", ".")])
+                                     defines=rpm_defines)
 
     def test_build_srpm_from_spec(self):
         planex.depend.build_srpm_from_spec(self.spec)

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -18,9 +18,11 @@ class RpmTests(unittest.TestCase):
     # pylint: disable=R0904
 
     def setUp(self):
+        rpm_defines = [("dist", ".el6"),
+                       ("_topdir", "."),
+                       ("_sourcedir", "%_topdir/SOURCES/%name")]
         self.spec = planex.spec.Spec("tests/data/ocaml-cohttp.spec",
-                                     defines=[("dist", ".el6"),
-                                              ("_topdir", ".")])
+                                     defines=rpm_defines)
 
     def test_bad_filename(self):
         self.assertRaises(planex.spec.SpecNameMismatch, planex.spec.Spec,


### PR DESCRIPTION
Remove the hard coded _sourcedir from spec and add a variable
in Makefile.rules which can be used to override it instead.

Signed-off-by: Euan Harris <euan.harris@citrix.com>