### PR TITLE
util: test file sizes before hashing

### DIFF
--- a/planex/util.py
+++ b/planex/util.py
@@ -151,5 +151,6 @@ def maybe_copy(src, dst, force=False):
     Copy a file from src to dst only if their contents differ.
     """
     if force or not (os.path.exists(dst) and
+                     os.stat(src).st_size == os.stat(dst).st_size and
                      hash_of_file(src) == hash_of_file(dst)):
         shutil.copy(src, dst)


### PR DESCRIPTION
Hashing file contents is expensive and unnecessary if the files are of
different lengths. Check the file sizes first and only hash them if they
are the same.

Signed-off-by: Simon J. Rowe <srowe@mose.org.uk>