### PR TITLE
planex-clone-sources: rename clone tool

### DIFF
--- a/planex/clonesources.py
+++ b/planex/clonesources.py
@@ -1,5 +1,5 @@
 """
-planex-clone: Checkout remote sources referred to by a spec (and link) file
+planex-clone-sources: Checkout sources referred to by a spec (and link) file
 """
 
 import argparse

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(name='planex',
           'console_scripts': [
               'planex-init = planex.init:_main',
               'planex-cache = planex.cache:_main',
+              'planex-clone-sources = planex.clonesources:_main',
               'planex-fetch = planex.fetch:_main',
               'planex-pin = planex.pin:_main',
               'planex-depend = planex.depend:main',


### PR DESCRIPTION
Move clone.py to clonesources.py so the top-level script can be called
planex-clone.

Signed-off-by: Simon Rowe <simon.rowe@eu.citrix.com>