### PR TITLE
[CP-17919] Add a wrapper around mock

### DIFF
--- a/planex/Makefile.rules
+++ b/planex/Makefile.rules
@@ -30,11 +30,10 @@ RPMBUILD_FLAGS ?= ${QUIET+--quiet} $(RPM_DEFINES)
 CREATEREPO ?= createrepo
 CREATEREPO_FLAGS ?= ${QUIET+--quiet} --update
 
-MOCK ?= mock
+MOCK ?= planex-build-mock
 MOCK_FLAGS ?= ${QUIET+--quiet} \
-              --configdir=$(TOPDIR)/mock  \
-              --resultdir=$(dir $@) --uniqueext=$(notdir $@) \
-              --disable-plugin=package_state
+              --configdir=$(TOPDIR)/mock \
+              --resultdir=$(dir $@)
 
 DEPEND ?= planex-depend
 DEPEND_FLAGS ?= $(RPM_DEFINES) --pins-dir $(PINSDIR) $(DEPEND_EXTRA_FLAGS)
@@ -130,7 +129,7 @@ $(TOPDIR)/SPECS/%.spec: SPECS/%.lnk SOURCES/%/patches.tar
 # runs at the same time as a createrepo is updating the repo metadata.
 %.rpm:
 	@echo [MOCK] $<
-	$(AT)flock --shared --timeout 300 ./$(TOPDIR)/RPMS $(MOCK) $(MOCK_FLAGS) --rebuild $<
+	$(AT)flock --shared --timeout 300 ./$(TOPDIR)/RPMS $(MOCK) $(MOCK_FLAGS) $<
 	@echo [CREATEREPO] $<
 	$(AT)flock --exclusive --timeout 300 ./$(TOPDIR)/RPMS $(CREATEREPO) $(CREATEREPO_FLAGS) ./$(TOPDIR)/RPMS
 

--- a/planex/mock.py
+++ b/planex/mock.py
@@ -1,0 +1,88 @@
+#!/usr/bin/python
+
+"""
+planex-build-mock: Wrapper around mock
+"""
+
+import subprocess
+import sys
+from uuid import uuid4
+
+import argparse
+import argcomplete
+from planex.util import add_common_parser_options
+
+
+def parse_args_or_exit(argv):
+    """
+    Parse command line options
+    """
+    parser = argparse.ArgumentParser(
+        description='Planex build system in a chroot (a mock wrapper)')
+    add_common_parser_options(parser)
+    parser.add_argument(
+        "--configdir", metavar="CONFIGDIR", default=None,
+        help="Change where the config files are found")
+    parser.add_argument(
+        "--resultdir", metavar="RESULTDIR", default=None,
+        help="Path for resulting files to be put")
+    parser.add_argument(
+        "-D", "--define", default=[], action="append",
+        help="--define='MACRO EXPR' \
+              define MACRO with value EXPR for the build")
+    parser.add_argument('srpms', metavar='SRPM', nargs='+',
+                        help='SRPM to build in the chroot')
+    argcomplete.autocomplete(parser)
+    return parser.parse_args(argv)
+
+
+def get_command_line(args, defaults):
+    """
+    Return mock command line and arguments
+    """
+    cmd = ['mock']
+    if args.quiet:
+        cmd.append('--quiet')
+    for define in args.define:
+        cmd.append('--define')
+        cmd.append(define)
+    if args.configdir is not None:
+        cmd.append('--configdir')
+        cmd.append(args.configdir)
+    if args.resultdir is not None:
+        cmd.append("--resultdir")
+        cmd.append(args.resultdir)
+    cmd.extend(defaults)
+    cmd.extend(args.srpms)
+    return cmd
+
+
+def main(argv):
+    """
+    Entry point arguments: srpm0 srpm1 srpm2 ...
+    At least one SRPM file (with ".src.rpm" or ".srpm" extension)
+    should be present.
+    """
+
+    defaults = [
+        "--uniqueext", uuid4().hex,
+        "--disable-plugin", "package_state",
+        "--rebuild"
+    ]
+
+    args = parse_args_or_exit(argv)
+
+    cmd = get_command_line(args, defaults)
+    return_value = subprocess.call(cmd)
+    sys.exit(return_value)
+
+
+def _main():
+    """
+    Entry point for setuptools CLI wrapper
+    """
+    main(sys.argv[1:])
+
+# Entry point when run directly
+if __name__ == "__main__":
+    _main()

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(name='planex',
               'planex-pin = planex.pin:_main',
               'planex-depend = planex.depend:main',
               'planex-extract = planex.extract:_main',
-              'planex-make-srpm = planex.makesrpm:_main'
+              'planex-make-srpm = planex.makesrpm:_main',
+              'planex-build-mock = planex.mock:_main'
           ]
       })


### PR DESCRIPTION
This PR introduces `planex-build-mock`. For the moment it is just wrapper around `mock`.
It has been tested by successfully rebuilding the `baggage` repo.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>