### PR TITLE
Add a (very) preliminary planex-chroot command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ MANIFEST
 build
 dist
 .rpmmacros
+planex.egg-info
 planex-build-root
 *.pyc
 srpmutil/srpmutil

--- a/planex/chroot.py
+++ b/planex/chroot.py
@@ -1,0 +1,64 @@
+"""
+planex-chroot: Start a docker container for developer builds of
+packages.
+"""
+
+import argparse
+import sys
+
+import argcomplete
+
+import planex
+import planex.spec
+import planex.util
+
+
+def start_container(args):
+    """
+    Start the docker container with the source directories availble.
+    """
+    path_maps = []
+
+    for package in args.package:
+        # Assuming an unpinned .spec file for now.
+        spec = planex.spec.Spec("SPECS/%s.spec" % (package))
+        path_maps.append(("myrepos/%s" % (spec.name()),
+                          "/build/rpmbuild/BUILD/%s-%s"
+                          % (spec.name(), spec.version())))
+
+    planex.util.start_container(path_maps, ("bash",))
+
+
+def parse_args_or_exit(argv=None):
+    """
+    Parse command line options
+    """
+    parser = argparse.ArgumentParser(description="""
+    Start a docker container for developer builds of packages.
+    """)
+    planex.util.add_common_parser_options(parser)
+    parser.add_argument("package", nargs="+",
+                        help="source to include in container")
+    argcomplete.autocomplete(parser)
+    return parser.parse_args(argv)
+
+
+def main(argv):
+    """
+    Entry point
+    """
+    planex.util.setup_sigint_handler()
+    args = parse_args_or_exit(argv)
+    start_container(args)
+
+
+def _main():
+    """
+    Entry point for setuptools CLI wrapper
+    """
+    main(sys.argv[1:])
+
+
+# Entry point when run directly
+if __name__ == "__main__":
+    _main()

--- a/planex/util.py
+++ b/planex/util.py
@@ -170,3 +170,25 @@ def makedirs(path):
             pass
         else:
             raise
+
+
+def start_container(path_maps, command):
+    """
+    Start the planex docker container.
+    """
+
+    # Add standard path maps
+    path_maps.append((os.getcwd(), "/build"))
+
+    cmd = ["docker", "run", "--privileged", "--rm", "-i", "-t",
+           "--volumes-from", "planex-persist"]
+
+    for (local, container) in path_maps:
+        cmd += ("-v", "%s:%s" % (os.path.realpath(local), container))
+
+    cmd += ("xenserver/planex:latest",)
+    cmd += command
+
+    logging.debug("running command: %s",
+                  (" ".join([pipes.quote(word) for word in cmd])))
+    subprocess.call(cmd)

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(name='planex',
           'console_scripts': [
               'planex-init = planex.init:_main',
               'planex-cache = planex.cache:_main',
+              'planex-chroot = planex.chroot:_main',
               'planex-clone-sources = planex.clonesources:_main',
               'planex-fetch = planex.fetch:_main',
               'planex-pin = planex.pin:_main',


### PR DESCRIPTION
This command will start a planex container suitable for developer
builds of the listed packages.  The source for the packages must
already be available (e.g., with the planex-clone-sources command).