### PR TITLE
Docker: change "build" user creation to avoid scanning large directories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ COPY planex.spec planex/
 RUN yum-builddep -y planex/planex.spec \
   && awk '/^Requires:/ { print $2 }' planex/planex.spec | xargs yum -y install \
   && yum clean all \
-  && useradd build --groups mock,wheel --home-dir /build
+  && mkdir /build
 
 # Copy source, build and install it.
 COPY . planex/

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -5,6 +5,6 @@ RUN yum -y install \
   https://xenserver.github.io/planex-release/release/rpm/el/planex-release-7-1.noarch.rpm \
   sudo
 RUN yum -y install planex
-RUN useradd build --groups mock,wheel --home-dir /build
+RUN mkdir /build
 COPY entry.sh /entry.sh
 ENTRYPOINT ["bash", "/entry.sh"]

--- a/docker/Dockerfile.unstable
+++ b/docker/Dockerfile.unstable
@@ -5,6 +5,6 @@ RUN yum -y install \
   https://xenserver.github.io/planex-release/unstable/rpm/el/planex-unstable-7-1.noarch.rpm \
   sudo
 RUN yum -y install planex
-RUN useradd build --groups mock,wheel --home-dir /build
+RUN mkdir /build
 COPY entry.sh /entry.sh
 ENTRYPOINT ["bash", "/entry.sh"]

--- a/docker/entry.sh
+++ b/docker/entry.sh
@@ -6,11 +6,18 @@ echo $@
 EXTUID=`stat -c %u /build`
 EXTGID=`stat -c %g /build`
 
-# Change 'build' UID in the container to match the owner of the
+# Create 'build' user in the container to match the owner of the
 # build directory, so that built packages will have the correct
 # owner outside the container.
-usermod --non-unique -u $EXTUID build
-groupmod --non-unique -g $EXTGID build
+groupadd build --gid $EXTGID      \
+               --non-unique
+useradd build --groups mock,wheel \
+              --home-dir /build   \
+              --uid $EXTUID       \
+              --gid $EXTGID       \
+              --no-create-home    \
+              --non-unique
+
 if [ -z "$1" ]; then
     exec su - build
 else


### PR DESCRIPTION
Running the "usermod" command to change the uid of a user has the side
effect of changing the uid in all files in the home of the user to match
the new uid.

When ran in a directory having a large number of files on a slow fs (NFS)
it can take awfully long time.

The planex docker image uses usermod to set up the "build" user inside the
container with a right uid, so it has the issue described above.

With this change the "build" user is created with the right uid in the
first place, so "usermod" is not needed, thus fixing the performance issue.


Signed-off-by: Istvan Szekeres <istvan.szekeres@citrix.com>