### PR TITLE
planex-container: allow running an interactive shell

### DIFF
--- a/docker/entry.sh
+++ b/docker/entry.sh
@@ -11,4 +11,8 @@ EXTGID=`stat -c %g /build`
 # owner outside the container.
 usermod --non-unique -u $EXTUID build
 groupmod --non-unique -g $EXTGID build
-su - build -c "$*"
+if [ -z "$1" ]; then
+    exec su - build
+else
+    exec su - build -c "$@"
+fi


### PR DESCRIPTION
Using the -c option runs the command without a controlling tty.  If no
arguments are specified, run an interactive shell that will have job
control etc.