### PR TITLE
CP-19321: Add planex-manifest tool

### DIFF
--- a/planex/Makefile.rules
+++ b/planex/Makefile.rules
@@ -38,6 +38,9 @@ MOCK_FLAGS ?= ${QUIET+--quiet} \
 DEPEND ?= planex-depend
 DEPEND_FLAGS ?= $(RPM_DEFINES) --pins-dir $(PINSDIR) $(DEPEND_EXTRA_FLAGS)
 
+MANIFEST ?= planex-manifest
+MANIFEST_FLAGS ?=
+
 ifdef QUIET
 AT = @
 endif
@@ -64,7 +67,9 @@ $(TOPDIR):
 	@ln -s ../mock $(TOPDIR)/mock
 	@mkdir $(TOPDIR)/RPMS
 	@mkdir $(TOPDIR)/SPECS
+	@mkdir $(TOPDIR)/MANIFESTS
 	@ln -s $(TOPDIR)/RPMS RPMS
+	@ln -s $(TOPDIR)/MANIFESTS MANIFESTS
 	$(AT)$(CREATEREPO) ${QUIET+--quiet} RPMS
 	@echo done
 
@@ -78,6 +83,14 @@ $(TOPDIR)/SPECS/%.spec: SPECS/%.spec
 	@mkdir -p $(dir $@)
 	@cp -lf $^ $@
 
+
+############################################################################
+# Manifest creation rules
+############################################################################
+
+MANIFESTS/%.json:
+	@echo [MANIFEST] $@
+	$(AT)$(MANIFEST) $(MANIFEST_FLAGS) $^ > $@
 
 ############################################################################
 # Source download rules

--- a/planex/depend.py
+++ b/planex/depend.py
@@ -13,7 +13,22 @@ import urlparse
 import argcomplete
 from planex.util import add_common_parser_options
 from planex.util import setup_sigint_handler
+from planex import manifest
 import planex.spec as pkg
+
+
+def create_manifest_deps(spec):
+    """
+    Create depependencies for package manifest
+    """
+    prereqs = spec.specpath()
+    spec_name = spec.name()
+    lnk_path = 'SPECS/{}.lnk'.format(spec_name)
+
+    if os.path.isfile(lnk_path):
+        prereqs += ' ' + lnk_path
+
+    print '{}: {}'.format(manifest.get_path(spec_name), prereqs)
 
 
 def build_srpm_from_spec(spec):
@@ -21,8 +36,9 @@ def build_srpm_from_spec(spec):
     Generate rules to build SRPM from spec
     """
     srpmpath = spec.source_package_path()
-    print '%s: %s %s' % (srpmpath, spec.specpath(),
-                         " ".join(spec.source_paths()))
+    print '%s: %s %s %s' % (srpmpath, spec.specpath(),
+                            " ".join(spec.source_paths()),
+                            manifest.get_path(spec.name()))
 
 
 def download_rpm_sources(spec):
@@ -173,6 +189,7 @@ def main():
     provides_to_rpm = package_to_rpm_map(specs.values())
 
     for spec in specs.itervalues():
+        create_manifest_deps(spec)
         build_srpm_from_spec(spec)
         download_rpm_sources(spec)
         build_rpm_from_srpm(spec)

--- a/planex/extract.py
+++ b/planex/extract.py
@@ -34,23 +34,6 @@ def extract_file(tar, name_in, name_out):
     os.utime(name_out, None)
 
 
-def write_manifest(spec_fh, spec, link):
-    """
-    Record the URLs of all remote sources in the spec file
-    """
-    branch = link.get('branch')
-    spec_fh.write("### manifest start\n")
-    spec_fh.write("# %s\n" % link['URL'])
-
-    for url in spec.source_urls():
-        if '://' in url:
-            if branch:
-                url = url.replace("%{branch}", branch)
-            spec_fh.write("# %s\n" % url)
-
-    spec_fh.write("### manifest end\n")
-
-
 def parse_patchseries(series, guard=None):
     """
     Parse series file and return the list of patches
@@ -193,7 +176,7 @@ def main(argv):
             spec = planex.spec.Spec(args.output + '.tmp',
                                     check_package_name=check_names,
                                     defines=macros)
-            write_manifest(spec_fh, spec, link)
+
             if 'branch' in link:
                 spec_fh.write("%%define branch %s\n" % link['branch'])
 

--- a/planex/manifest.py
+++ b/planex/manifest.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+
+"""
+planex-manifest: Generate manifest in JSON format from spec/link files.
+
+Every invocation prints the manifest for a single package in stdout.
+"""
+
+import json
+import argparse
+import argcomplete
+
+from planex.util import add_common_parser_options
+from planex.spec import Spec
+from planex.repository import Repository
+
+
+def parse_cmdline():
+    """Parse command line options"""
+
+    parser = argparse.ArgumentParser(
+        description='Generate manifest in JSON format from spec/link files'
+    )
+
+    add_common_parser_options(parser)
+
+    parser.add_argument(
+        'specfile_path',
+        metavar='SPEC',
+        help='path/to/<spec_file>'
+    )
+
+    parser.add_argument(
+        'lnkfile_path',
+        metavar='LNK',
+        nargs='?',
+        default=None,
+        help='path/to/<lnk_file>'
+    )
+
+    argcomplete.autocomplete(parser)
+    return parser.parse_args()
+
+
+def get_path(package_name):
+    """Get relative path to manifest file for package."""
+    return './MANIFESTS/{}.json'.format(package_name)
+
+
+def generate_manifest(spec, link=None):
+    """Record info of all remote sources in the spec/link files.
+
+    Args:
+        spec (planex.spec.Spec): package's spec file
+        link (dict/None): package's link file, if applicable
+
+    Returns:
+        (dict): manifest of the remote sources
+                needed to create the SRPM.
+        Format:
+        {
+            "spec": {
+                "source0": {
+                    "url": <source0_url>,
+                    "sha1": <source0_sha1>
+                },
+                "source1": ...
+                .
+                .
+            },
+            "lnk": {
+                "url": <lnk_url>,
+                "sha1": <lnk_sha1>
+            }
+        }
+    """
+    branch = None
+
+    if link is not None:
+        branch = link.get('branch')
+
+    manifest = {'spec': {}}
+    source_urls = [url for url in spec.source_urls() if '://' in url]
+
+    for i, url in enumerate(source_urls):
+        if branch:
+            url = url.replace("%{branch}", branch)
+
+        # Sources taken from artifactory do not have SHA1
+        if 'repo.citrite.net' not in url:
+            repo_ref = Repository(url)
+            sha1 = repo_ref.sha1
+        else:
+            sha1 = None
+
+        manifest['spec']['source' + str(i)] = {'url': url, 'sha1': sha1}
+
+    if link is not None:
+        repo_ref = Repository(link['URL'])
+        sha1 = repo_ref.sha1
+        manifest['lnk'] = {'url': link['URL'], 'sha1': sha1}
+
+    return manifest
+
+
+def main():
+    """Entry point."""
+
+    args = parse_cmdline()
+
+    spec = Spec(args.specfile_path)
+
+    if args.lnkfile_path is not None:
+        with open(args.lnkfile_path) as link_fh:
+            link = json.load(link_fh)
+    else:
+        link = None
+
+    manifest = generate_manifest(spec, link)
+    print json.dumps(manifest, indent=4)
+
+
+if __name__ == '__main__':
+    main()

--- a/planex/util.py
+++ b/planex/util.py
@@ -170,3 +170,26 @@ def makedirs(path):
             pass
         else:
             raise
+
+
+def git_ls_remote(url, ref=None, *options):
+    """
+    Run 'git ls-remote' command.
+    """
+    cmd = ['git', 'ls-remote'] + list(options) + [url]
+
+    if ref is not None:
+        cmd.append(ref)
+
+    proc = subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE
+    )
+
+    stdout, stderr = proc.communicate()
+
+    if stderr:
+        raise RuntimeError(stderr)
+
+    return stdout

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(name='planex',
               'planex-depend = planex.depend:main',
               'planex-extract = planex.extract:_main',
               'planex-make-srpm = planex.makesrpm:_main',
+              'planex-manifest = planex.manifest:main',
               'planex-build-mock = planex.mock:_main'
           ]
       })

--- a/tests/data/bitbucket-repo.json
+++ b/tests/data/bitbucket-repo.json
@@ -3,18 +3,24 @@
 	"URL": "https://code.citrite.net/rest/archive/latest/projects/~SIMONR/repos/brocade-bna/archive?format=tgz#/Brocade-bna-3.2.1.1.tar.gz",
 	"clone_URL": "ssh://git@code.citrite.net/~SIMONR/brocade-bna.git",
 	"branch": "master",
-	"tag": null
+	"tag": null,
+	"git_ls_remote_out": "7cdf99ff799b4bd1f33bcde2c79ac56e603f2c23\trefs/heads/master\n",
+	"sha1": "7cdf99ff799b4bd1f33bcde2c79ac56e603f2c23"
     },
     {
 	"URL": "https://code.citrite.net/rest/archive/latest/projects/XS/repos/linux-firmware/archive?at=refs%2Ftags%2F20160622&format=tar.gz#/linux-firmware.tar.gz",
 	"clone_URL": "ssh://git@code.citrite.net/XS/linux-firmware.git",
 	"branch": null,
-	"tag": "20160622"
+	"tag": "20160622",
+	"git_ls_remote_out": "dca884016afa9f954baa69e3e28b8f2aab3b6921\trefs/tags/20160622\n",
+	"sha1": "dca884016afa9f954baa69e3e28b8f2aab3b6921"
     },
     {
 	"URL": "https://code.citrite.net/rest/archive/latest/projects/XS/repos/lvm2/archive?at=refs%2Fheads%2Fxenserver_patches&format=tar#/lvm2.patches.tar",
 	"clone_URL": "ssh://git@code.citrite.net/XS/lvm2.git",
 	"branch": "xenserver_patches",
-	"tag": null
+	"tag": null,
+	"git_ls_remote_out": "dc69fe697517ce922de8dca822d75c9bb7b59b70\trefs/heads/xenserver_patches\n",
+	"sha1": "dc69fe697517ce922de8dca822d75c9bb7b59b70"
     }
 ]

--- a/tests/data/github-repo.json
+++ b/tests/data/github-repo.json
@@ -3,6 +3,8 @@
 	"URL": "https://github.com/xapi-project/xen-api/archive/v1.10.1/xen-api-1.10.1.tar.gz",
 	"clone_URL": "ssh://git@github.com/xapi-project/xen-api.git",
 	"branch": null,
-	"tag": "v1.10.1"
+	"tag": "v1.10.1",
+	"git_ls_remote_out": "15ab3b9221b5dbf0831edac6ecb64659d8c66786\trefs/tags/v1.10.1\n",
+	"sha1": "15ab3b9221b5dbf0831edac6ecb64659d8c66786"
     }
 ]

--- a/tests/data/gitweb-repo.json
+++ b/tests/data/gitweb-repo.json
@@ -3,12 +3,16 @@
 	"URL": "http://hg.uk.xensource.com/git/carbon/trunk/xsconsole.git/snapshot/refs/heads/master#/xsconsole.tar.bz2",
 	"clone_URL": "git://hg.uk.xensource.com/carbon/trunk/xsconsole.git",
 	"branch": "master",
-	"tag": null
+	"tag": null,
+	"git_ls_remote_out": "bc485b12d68ed2f675165051b0f484e844275222\trefs/heads/master\n",
+	"sha1": "bc485b12d68ed2f675165051b0f484e844275222"
     },
     {
 	"URL": "http://hg.uk.xensource.com/git/carbon/trunk-ring0/driver-emulex-be2net.git/snapshot/refs/tags/11.0.235.4.tar.gz#/emulex-be2net-11.0.235.4.tar.gz",
 	"clone_URL": "git://hg.uk.xensource.com/carbon/trunk-ring0/driver-emulex-be2net.git",
 	"branch": null,
-	"tag": "11.0.235.4"
+	"tag": "11.0.235.4",
+	"git_ls_remote_out": "7efa24559d3d26eea3e3744a6a789eb7b5322e28\trefs/tags/11.0.235.4\n",
+	"sha1": "7efa24559d3d26eea3e3744a6a789eb7b5322e28"
     }
 ]

--- a/tests/data/manifest/blktap.json
+++ b/tests/data/manifest/blktap.json
@@ -1,0 +1,12 @@
+{
+    "spec": {
+        "source0": {
+            "url": "http://hg.uk.xensource.com/git/carbon/trunk/blktap.git/snapshot/refs/tags/v3.3.0#/blktap-3.3.0.tar.gz", 
+            "sha1": "ddb48b561342d7742ec1dbd6c4987c1f4add9387"
+        }
+    }, 
+    "lnk": {
+        "url": "http://hg.uk.xensource.com/git/carbon/trunk/blktap.pg.git/snapshot/refs/heads/master#/blktap.patches.tar", 
+        "sha1": "ac9032660c02be11afdb7cc8ad23be2f1aa9b7ce"
+    }
+}

--- a/tests/data/manifest/blktap.lnk
+++ b/tests/data/manifest/blktap.lnk
@@ -1,0 +1,6 @@
+{
+    "URL": "http://hg.uk.xensource.com/git/carbon/trunk/blktap.pg.git/snapshot/refs/heads/master#/blktap.patches.tar",
+    "specfile": "blktap.spec",
+    "patchqueue": "master",
+    "branch": "trunk"
+}

--- a/tests/data/manifest/blktap.spec
+++ b/tests/data/manifest/blktap.spec
@@ -1,0 +1,153 @@
+%define branch trunk
+Summary: blktap user space utilities
+Name: blktap
+Version: 3.3.0
+Release: xs.1
+License: BSD
+Group: System/Hypervisor
+URL: https://github.com/xapi-project/blktap
+Patch0: %{name}-CA-211529-Corrected-tapdisk-stats-definitions
+Patch1: %{name}-CP-18192-Removed-code-for-xlvhd-thin-provisioning
+Patch2: %{name}-CP-18025-Change-blktap-license-from-gplv2-to-bsd
+Patch3: %{name}-CP-18025-Use-bsd-compliant-list.h
+Patch4: %{name}-CP-18025-Discontinue-use-of-upstream-nbd-header-file
+Patch5: %{name}-CP-18025-Use-glibc-alternative-to-page-size-macro
+Patch6: %{name}-CP-18025-Remove-dependence-on-linux-log2.h
+Patch7: %{name}-pull_request_187__CP-17399_fix_resource_leaking_asprintf
+Patch8: %{name}-pull_request_188__introduce_a_new_block_backend_called_ntnx
+Patch9: %{name}-pull_request_190__ca-219462__remove_lock.h_and_lock.c
+Patch10: %{name}-pull_request_191__CA-220042_sigact.sa_mask_is_not_initialized_CID-5755
+Patch11: %{name}-pull_request_192__CA-220041_blkif_used_after_freed_CID-57556
+Patch12: %{name}-pull_request_193__CA-220000_memory_leak_from_variable_path_CID-57593
+Patch13: %{name}-pull_request_194__CA-220002_resource_leak_for_memory_allocated_to_pname_CID-57549
+Patch14: %{name}-pull_request_195__CA-220003_Resource_leak_for_memory_allocated_to_target_CID-57413
+Patch15: %{name}-pull_request_186__CA-215080_CID-63812_Uninitialized_scalar_variable
+Patch16: %{name}-pull_request_196__ca-215084__bug_fixes_in_lvm-util.c
+Patch17: %{name}-pull_request_198__ca-220226__fix_bugs_in_part-util.c
+Patch18: %{name}-pull_request_199__ca-220433__replace_format_with_string_literal_in_tap-ctl-list.c
+Patch19: %{name}-pull_request_200__ca-220434__return_err_instead_of_0
+Patch20: %{name}-pull_request_201__ca-220436__fix_resource_leak_in_tap-ctl-list.c
+Patch21: %{name}-pull_request_203__ca-220444__fix_possible_race_condition
+Patch22: %{name}-pull_request_202__ca-220442__check_length_of_socket_name_before_copying
+Patch23: %{name}-pull_request_206__ca-220463__ensure_string_fits_in_buffer_before_copying
+Patch24: %{name}-pull_request_204__ca-220478__fix_leaked_socket_file_descriptor
+Patch25: %{name}-pull_request_205__ca-220479__remove_nonsensical_checks
+Patch26: %{name}-pull_request_213__ca-220518__potentially_uninitialised_variable_used
+Patch27: %{name}-pull_request_208__ca-220482__check_return_value_of_fwrite
+Patch28: %{name}-pull_request_212_1__cid-11258_unchecked_return_value_from_library
+Patch29: %{name}-pull_request_212_2__cid-28562_dereference_null_return_value
+Patch30: %{name}-pull_request_212_3__cid-28703_destination_buffer_too_small
+Patch31: %{name}-pull_request_212_4__cid-28739_double_close
+Patch32: %{name}-pull_request_212_5__cid-62178_cid-57555_read_or_write_to_pointer_after_free
+Patch33: %{name}-pull_request_197__cp-18757__refactor_the_way_we_use_ctx_fd_CID-28676
+Patch34: %{name}-pull_request_207__ca-220481__fixes_in_tap_ctl_stats_fwrite
+Patch35: %{name}-pull_request_210__ca-215114__resource_leak_in_vhd_util_coalesce_open_output
+Patch36: %{name}-pull_request_214__ca-216250__fix_resource_leak
+Patch37: %{name}-pull_request_217__ca-221814__fix_resource_leak_in_vhdi_create
+Patch38: %{name}-pull_request_218__ca-221864__fix_bugs_in_vhd_journal_read_locators
+Patch39: %{name}-pull_request_220__ca-222003__fix_null_dereference_bug
+Patch40: %{name}-pull_request_221__ca-216249__check_length_of_socket_name_before_copying
+Patch41: %{name}-pull_request_222__ca-222077__fix_bugs_in_td_fdreceiver_start
+Patch42: %{name}-pull_request_223__ca-222139__resource_leak_in_tap_ctl_allocate_device
+Patch43: %{name}-pull_request_225__ca-222242__memset_1_byte_instead_of_4
+Patch44: %{name}-pull_request_226__ca-222244__fix_resource_leaks_in_vhd_shift_metadata
+Patch45: %{name}-pull_request_228__CA-222124_Handle_race_condition_in_tap-ctl_spawn
+Patch46: %{name}-pull_request_229__ca-223652__add_delay_to_reduce_number_of_syslog_messages
+Patch47: %{name}-pull_request_231__cp-14449__fix_version_and_release_tag_in_specfile
+Patch48: %{name}-pull_request_219__ca-221904__vhd_create_einval_report_errors
+Patch49: %{name}-add_coverity_model.c_to_support_asprintf
+Patch50: %{name}-pull_request_230__CA-225067-tap_ctl_-spawn-create-move-tapdisk-to-cgro
+Source0: http://hg.uk.xensource.com/git/carbon/%{branch}/blktap.git/snapshot/refs/tags/v%{version}#/%{name}-%{version}.tar.gz
+
+BuildRoot: %{_tmppath}/%{name}-%{release}-buildroot
+Obsoletes: xen-blktap
+BuildRequires: e2fsprogs-devel, libaio-devel, systemd, autogen, autoconf, automake, libtool, libuuid-devel
+BuildRequires: xen-devel, kernel-devel, xen-dom0-libs-devel, zlib-devel, xen-libs-devel
+Requires(post): systemd
+Requires(preun): systemd
+Requires(postun): systemd
+
+%description
+Blktap creates kernel block devices which realize I/O requests to
+processes implementing virtual hard disk images entirely in user
+space.
+
+Typical disk images may be implemented as files, in memory, or
+stored on other hosts across the network. The image drivers included
+with tapdisk can map disk I/O to sparse file images accessed through
+Linux DIO/AIO and VHD images with snapshot functionality.
+
+This packages includes the control utilities needed to create
+destroy and manipulate devices ('tap-ctl'), the 'tapdisk' driver
+program to perform tap devices I/O, and a number of image drivers.
+
+%package devel
+Summary: BlkTap Development Headers and Libraries
+Requires: blktap = %{version}
+Group: Development/Libraries
+Obsoletes: xen-blktap
+
+%description devel
+Blktap and VHD development files.
+
+%prep
+%setup -q -n %{name}-v%{version}
+patch -p1 < mk/blktap-udev-ignore-tapdevs.patch
+%autosetup -T -D -p1
+
+%build
+sh autogen.sh
+%configure
+%{?cov_wrap} make
+
+%install
+rm -rf %{buildroot}
+make install DESTDIR=%{buildroot}
+mkdir -p %{buildroot}%{_localstatedir}/log/blktap
+
+%files
+%defattr(-,root,root,-)
+%doc
+%{_libdir}/*.so
+%{_libdir}/*.so.*
+%{_bindir}/vhd-util
+%{_bindir}/vhd-update
+%{_bindir}/vhd-index
+%{_bindir}/tapback
+%{_bindir}/cpumond
+%{_sbindir}/lvm-util
+%{_sbindir}/tap-ctl
+%{_sbindir}/td-util
+%{_sbindir}/td-rated
+%{_sbindir}/part-util
+%{_sbindir}/vhdpartx
+%{_libexecdir}/tapdisk
+%{_sysconfdir}/udev/rules.d/blktap.rules
+%{_sysconfdir}/logrotate.d/blktap
+%{_sysconfdir}/xensource/bugtool/tapdisk-logs.xml
+%{_sysconfdir}/xensource/bugtool/tapdisk-logs/description.xml
+%{_localstatedir}/log/blktap
+%{_unitdir}/tapback.service
+%{_unitdir}/cpumond.service
+
+%files devel
+%defattr(-,root,root,-)
+%doc
+%{_libdir}/*.a
+%{_libdir}/*.la
+%{_includedir}/vhd/*
+%{_includedir}/blktap/*
+
+%post
+%systemd_post tapback.service
+%systemd_post cpumond.service
+
+%preun
+%systemd_preun tapback.service
+%systemd_preun cpumond.service
+
+%postun
+%systemd_postun tapback.service
+%systemd_postun cpumond.service
+
+%changelog

--- a/tests/data/manifest/branding-xenserver.json
+++ b/tests/data/manifest/branding-xenserver.json
@@ -1,0 +1,8 @@
+{
+    "spec": {
+        "source0": {
+            "url": "https://code.citrite.net/rest/archive/latest/projects/XS/repos/branding/archive?format=tar.gz#/branding-xenserver.tar.gz", 
+            "sha1": "39ae2ff11cfc5bde4724c67aae0aca77d2636664"
+        }
+    }
+}

--- a/tests/data/manifest/branding-xenserver.spec
+++ b/tests/data/manifest/branding-xenserver.spec
@@ -1,0 +1,24 @@
+Name: branding-xenserver
+Version: 7.0.91
+Release: 1
+Summary: Build-time branding for XenServer
+License: Proprietary
+Source0: https://code.citrite.net/rest/archive/latest/projects/XS/repos/branding/archive?format=tar.gz#/%{name}.tar.gz
+BuildArch: noarch
+BuildRequires: python
+
+Requires: python
+
+%description
+Files containing platform and product versioning, EULA etc.
+
+%prep
+%autosetup
+
+%install
+%{__make} -f Citrix/XenServer/Makefile install DESTDIR=%{buildroot}
+
+
+%files
+%{_sysconfdir}/rpm/macros.*
+%{_usrsrc}/branding

--- a/tests/data/manifest/git_ls_remote_out.json
+++ b/tests/data/manifest/git_ls_remote_out.json
@@ -1,0 +1,8 @@
+{
+    "branding-xenserver": "39ae2ff11cfc5bde4724c67aae0aca77d2636664\trefs/heads/master\n",
+    "vhostmd": "8c25514011ff2081ccb6b988f2395d2be83570e7\trefs/heads/xenserver_patches\n",
+    "blktap": [
+        "db8d9edd203460adba4b9175971c2cfc14ac0f64\trefs/tags/v3.3.0\nddb48b561342d7742ec1dbd6c4987c1f4add9387\trefs/tags/v3.3.0^{}\n",
+        "ac9032660c02be11afdb7cc8ad23be2f1aa9b7ce\trefs/heads/master\n"
+    ]
+}

--- a/tests/data/manifest/vhostmd.json
+++ b/tests/data/manifest/vhostmd.json
@@ -1,0 +1,12 @@
+{
+    "spec": {
+        "source0": {
+            "url": "https://repo.citrite.net/xs-local-contrib/vhostmd/vhostmd-0.4.tar.gz", 
+            "sha1": null
+        }
+    }, 
+    "lnk": {
+        "url": "https://code.citrite.net/rest/archive/latest/projects/XS/repos/vhostmd/archive?at=refs%2Fheads%2Fxenserver_patches&format=tar#/vhostmd.patches.tar", 
+        "sha1": "8c25514011ff2081ccb6b988f2395d2be83570e7"
+    }
+}

--- a/tests/data/manifest/vhostmd.lnk
+++ b/tests/data/manifest/vhostmd.lnk
@@ -1,0 +1,5 @@
+{
+    "URL": "https://code.citrite.net/rest/archive/latest/projects/XS/repos/vhostmd/archive?at=refs%2Fheads%2Fxenserver_patches&format=tar#/vhostmd.patches.tar",
+    "specfile": "SPECS/vhostmd.spec",
+    "patches": "SOURCES"
+}

--- a/tests/data/manifest/vhostmd.spec
+++ b/tests/data/manifest/vhostmd.spec
@@ -1,0 +1,102 @@
+# This prevents vhostmd-debuginfo-%{version}-%{release}.rpm being built
+%define debug_packages	%{nil}
+%define debug_package %{nil}
+
+Name:           vhostmd
+Version:        0.4
+Release:        xs28
+Epoch:          0
+Summary:        Virtual Host Metrics Daemon
+
+Group:          Application/Productivity
+License:        GPL
+URL:            http://www.novell.com
+Source0:        https://repo.citrite.net/xs-local-contrib/vhostmd/%{name}-%{version}.tar.gz
+Source1:        xe-vhostmd
+patch0:         patch-etc_init.d_vhostmd
+patch1:         patch-fix-enable-xenctrl-configure-opt
+patch2:         patch-etc_vhostmd_vhostmd.conf
+patch3:         patch-xen-4.1
+patch4:         de-perl.patch
+patch5:         patch-remove-xs-h
+patch6:         configure-dlopen.patch
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}
+BuildRequires:	libtool, autoconf, automake, libxml2-devel, xen-dom0-devel, xen-libs-devel
+
+%description
+vhostmd provides a "metrics communication channel" between a host and
+its hosted virtual machines, allowing limited introspection of host
+resource usage from within virtual machines.  This functionality may be
+useful in hosting environments, giving virtual machine administrators
+a limited view of host resource consumption - potentially explaining a
+performance degradation within the virtual machine.
+
+vhostmd will periodically write metrics to a disk.  The metrics to
+write, how often, and where to write them are all adjustable via the
+/etc/vhostmd/vhostmd.conf configuration file.  The disk can then be
+surfaced read-only to virtual machines using tools provided by the 
+virtualization platform of the host.
+
+%prep
+%setup -q -n %{name}-%{version}
+%patch4 -p1 -b .de-perl
+%patch0 -p1 -b .xs-init-script
+%patch1 -p1 -b .xs-fix-configure-opt
+%patch2 -p1 -b .xs-vhostmd-conf
+%patch3 -p1 -b .xs-xen-4.1
+%patch5 -p1 -b .xs-remove-xs-h
+%patch6 -p0 -b .xs-configure-dlopen
+
+%build
+sh autogen.sh
+%configure --enable-xenctrl
+make %{?_smp_mflags}
+
+%install
+rm -rf %{buildroot}
+make install DESTDIR=%{buildroot}
+install -m 755 %{_sourcedir}/xe-vhostmd %{buildroot}/usr/sbin
+
+%clean
+rm -rf %{buildroot} 
+
+%preun
+if [ "$1" = 0 ] ; then
+  chkconfig --del vhostmd
+fi
+
+%files 
+%defattr(-,root,root,-)
+/usr/sbin/vhostmd
+/usr/sbin/vm-dump-metrics
+/usr/sbin/xe-vhostmd
+%{_mandir}/man1/vm-dump-metrics.1.gz
+%{_mandir}/man8/vhostmd.8.gz
+%{_libdir}/libmetrics.so.0.0.0
+%{_libdir}/libmetrics.so.0
+%{_libdir}/libmetrics.so
+%{_libdir}/libmetrics.a
+%{_libdir}/libmetrics.la
+/usr/include/vhostmd/libmetrics.h
+/usr/share/vhostmd/scripts/pagerate.py
+/usr/share/vhostmd/scripts/pagerate.pyc
+/usr/share/vhostmd/scripts/pagerate.pyo
+/usr/share/doc/vhostmd/README
+/usr/share/doc/vhostmd/mdisk.xml
+/usr/share/doc/vhostmd/vhostmd.dtd
+/usr/share/doc/vhostmd/vhostmd.xml
+/usr/share/doc/vhostmd/metric.dtd
+%config /etc/init.d/vhostmd
+%config /etc/vhostmd/vhostmd.conf
+%config /etc/vhostmd/vhostmd.dtd
+%config /etc/vhostmd/metric.dtd
+
+%changelog
+* Wed May 02 2012 <support@citrix.com> - added xe-vhostmd
+* Thu Nov 03 2011 <support@citrix.com> - XenServer vhostmd package
+- removed post-install section: do not start vhostmd automatically by default.
+- preun is no longer run on upgrade, only on uninstalling all versions.
+* Wed Apr 28 2010 <support@citrix.com> - XenServer vhostmd package
+- updated config following testing at SAP
+* Tue Mar 10 2009 <support@citrix.com> - XenServer vhostmd package
+- initial version

--- a/tests/test_bitbucket_repository.py
+++ b/tests/test_bitbucket_repository.py
@@ -4,6 +4,7 @@
 
 import json
 import unittest
+import mock
 
 import planex.repository
 
@@ -16,9 +17,12 @@ class BasicTests(unittest.TestCase):
         with open("tests/data/bitbucket-repo.json") as fileh:
             self.data = json.load(fileh)
 
-    def test_urls(self):
+    @mock.patch('planex.repository.git_ls_remote')
+    def test_urls(self, mock_git_ls_remote):
         for tcase in self.data:
+            mock_git_ls_remote.return_value = tcase['git_ls_remote_out']
             repo = planex.repository.Repository(tcase['URL'])
             self.assertEqual(repo.clone_url, tcase['clone_URL'])
             self.assertEqual(repo.branch, tcase['branch'])
             self.assertEqual(repo.tag, tcase['tag'])
+            self.assertEqual(repo.sha1, tcase['sha1'])

--- a/tests/test_depend.py
+++ b/tests/test_depend.py
@@ -29,7 +29,8 @@ class BasicTests(unittest.TestCase):
             "./SRPMS/ocaml-cohttp-0.9.8-1.el6.src.rpm: "
             "tests/data/ocaml-cohttp.spec "
             "./SOURCES/ocaml-cohttp/ocaml-cohttp-0.9.8.tar.gz "
-            "./SOURCES/ocaml-cohttp/ocaml-cohttp-init\n")
+            "./SOURCES/ocaml-cohttp/ocaml-cohttp-init "
+            "./MANIFESTS/ocaml-cohttp.json\n")
 
     def test_download_rpm_sources(self):
         planex.depend.download_rpm_sources(self.spec)

--- a/tests/test_github_repository.py
+++ b/tests/test_github_repository.py
@@ -4,6 +4,7 @@
 
 import json
 import unittest
+import mock
 
 import planex.repository
 
@@ -16,9 +17,12 @@ class BasicTests(unittest.TestCase):
         with open("tests/data/github-repo.json") as fileh:
             self.data = json.load(fileh)
 
-    def test_urls(self):
+    @mock.patch('planex.repository.git_ls_remote')
+    def test_urls(self, mock_git_ls_remote):
         for tcase in self.data:
+            mock_git_ls_remote.return_value = tcase['git_ls_remote_out']
             repo = planex.repository.Repository(tcase['URL'])
             self.assertEqual(repo.clone_url, tcase['clone_URL'])
             self.assertEqual(repo.branch, tcase['branch'])
             self.assertEqual(repo.tag, tcase['tag'])
+            self.assertEqual(repo.sha1, tcase['sha1'])

--- a/tests/test_gitweb_repository.py
+++ b/tests/test_gitweb_repository.py
@@ -4,6 +4,7 @@
 
 import json
 import unittest
+import mock
 
 import planex.repository
 
@@ -16,9 +17,12 @@ class BasicTests(unittest.TestCase):
         with open("tests/data/gitweb-repo.json") as fileh:
             self.data = json.load(fileh)
 
-    def test_urls(self):
+    @mock.patch('planex.repository.git_ls_remote')
+    def test_urls(self, mock_git_ls_remote):
         for tcase in self.data:
+            mock_git_ls_remote.return_value = tcase['git_ls_remote_out']
             repo = planex.repository.Repository(tcase['URL'])
             self.assertEqual(repo.clone_url, tcase['clone_URL'])
             self.assertEqual(repo.branch, tcase['branch'])
             self.assertEqual(repo.tag, tcase['tag'])
+            self.assertEqual(repo.sha1, tcase['sha1'])

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,84 @@
+import json
+import unittest
+import mock
+
+import planex.spec
+import planex.manifest
+
+
+class BasicTests(unittest.TestCase):
+    # unittest.TestCase has more methods than Pylint permits
+    # pylint: disable=R0904
+    def setUp(self):
+        path = 'tests/data/manifest/{}.{}'
+        self.name_1 = 'branding-xenserver'
+        self.name_2 = 'vhostmd'
+        self.name_3 = 'blktap'
+
+        self.spec = {}
+        self.spec[self.name_1] = planex.spec.Spec(
+            path.format(self.name_1, 'spec')
+        )
+        self.spec[self.name_2] = planex.spec.Spec(
+            path.format(self.name_2, 'spec')
+        )
+        self.spec[self.name_3] = planex.spec.Spec(
+            path.format(self.name_3, 'spec')
+        )
+
+        self.link = {}
+        self.link[self.name_1] = None
+        with open(path.format(self.name_2, 'lnk')) as fileh:
+            self.link[self.name_2] = json.load(fileh)
+        with open(path.format(self.name_3, 'lnk')) as fileh:
+            self.link[self.name_3] = json.load(fileh)
+
+        self.expected_manifest = {}
+        with open(path.format(self.name_1, 'json')) as fileh:
+            self.expected_manifest[self.name_1] = json.load(fileh)
+        with open(path.format(self.name_2, 'json')) as fileh:
+            self.expected_manifest[self.name_2] = json.load(fileh)
+        with open(path.format(self.name_3, 'json')) as fileh:
+            self.expected_manifest[self.name_3] = json.load(fileh)
+
+        with open(path.format('git_ls_remote_out', 'json')) as fileh:
+            self.git_ls_remote_out = json.load(fileh)
+
+    @mock.patch('planex.repository.git_ls_remote')
+    def test_generate_manifest_1(self, mock_git_ls_remote):
+        # Standard repo (specfile only)
+
+        mock_git_ls_remote.return_value = self.git_ls_remote_out[self.name_1]
+
+        manifest = planex.manifest.generate_manifest(
+            self.spec[self.name_1],
+            self.link[self.name_1]
+        )
+
+        self.assertEqual(manifest, self.expected_manifest[self.name_1])
+
+    @mock.patch('planex.repository.git_ls_remote')
+    def test_generate_manifest_2(self, mock_git_ls_remote):
+        # Source tarball and patchqueue (specfile and lnkfile)
+
+        mock_git_ls_remote.return_value = self.git_ls_remote_out[self.name_2]
+
+        manifest = planex.manifest.generate_manifest(
+            self.spec[self.name_2],
+            self.link[self.name_2]
+        )
+
+        self.assertEqual(manifest, self.expected_manifest[self.name_2])
+
+    @mock.patch('planex.repository.git_ls_remote')
+    def test_generate_manifest_3(self, mock_git_ls_remote):
+        # Repo and patchqueue (specfile and lnkfile)
+
+        mock_git_ls_remote.side_effect = self.git_ls_remote_out[self.name_3]
+
+        manifest = planex.manifest.generate_manifest(
+            self.spec[self.name_3],
+            self.link[self.name_3]
+        )
+
+        self.assertEqual(manifest, self.expected_manifest[self.name_3])


### PR DESCRIPTION
planex-manifest is a command line tool that prints a manifest
in stdout, given a package's spec and lnk (if applicable) files.

A package's SRPM now depends on its manifest file and
a manifest file now depends on its package's spec/lnk files.

Signed-off-by: Kostas Ladopoulos <konstantinos.ladopoulos@citrix.com>