### PR TITLE
repository: handle BitBucket URLs with hashes

### DIFF
--- a/planex/repository.py
+++ b/planex/repository.py
@@ -138,18 +138,19 @@ class Repository(object):
         )
 
         self.dir_name = path[7]
-        query_str = urlparse.unquote(self.url.query)
-        if query_str.startswith('at='):
-            query = query_str[3:]
-            if '&' in query:
-                query = query[:query.find('&')]
-            query_path = query.split('/')
-            if query_path[1] == 'tags':
-                self.tag = query_path[2]
-            elif query_path[1] == 'heads':
-                self.branch = query_path[2]
+        query_dict = urlparse.parse_qs(self.url.query)
+        if 'at' in query_dict:
+            query = query_dict['at'][0]
+            if '/' in query:
+                query_path = query.split('/')
+                if query_path[1] == 'tags':
+                    self.tag = query_path[2]
+                elif query_path[1] == 'heads':
+                    self.branch = query_path[2]
+                else:
+                    self.branch = 'master'
             else:
-                self.branch = 'master'
+                self.tag = query
         else:
             self.branch = 'master'
 

--- a/tests/data/bitbucket-repo.json
+++ b/tests/data/bitbucket-repo.json
@@ -22,5 +22,13 @@
 	"tag": null,
 	"git_ls_remote_out": "dc69fe697517ce922de8dca822d75c9bb7b59b70\trefs/heads/xenserver_patches\n",
 	"sha1": "dc69fe697517ce922de8dca822d75c9bb7b59b70"
+    },
+    {
+	"URL": "https://code.citrite.net/rest/archive/latest/projects/XS/repos/linux-4.x.pg/archive?at=b17a2301da0&format=tar#/kernel.patches.tar",
+	"clone_URL": "ssh://git@code.citrite.net/XS/linux-4.x.pg.git",
+	"branch": null,
+	"tag": "b17a2301da0",
+	"git_ls_remote_out": "",
+	"sha1": ""
     }
 ]


### PR DESCRIPTION
Fix the parsing of the query string when it does not start with
'refs/...'.

Signed-off-by: Simon Rowe <simon.rowe@eu.citrix.com>