### PR TITLE
Makefile.rules: Fail if deps can't be rebuilt

### DIFF
--- a/planex/Makefile.rules
+++ b/planex/Makefile.rules
@@ -172,6 +172,6 @@ $(DEPS): $(TOPDIR) $(wildcard $(PINSFILE) $(PINSDIR)/*.spec) \
 	@echo Updating dependencies...
 	$(AT)$(DEPEND) $(DEPEND_FLAGS) $(TOPDIR)/SPECS/*.spec > $@
 
--include $(DEPS)
+include $(DEPS)
 
 # vim:ft=make:


### PR DESCRIPTION
If the deps file cannot be created or updated, we can't proceed with
the build.   We still use the -include directive for pindeps because
rebuilding it is optional - there might not be any pinned packages in
the repository.

Signed-off-by: Euan Harris <euan.harris@citrix.com>