### PR TITLE
CA-228222 Handle commitish references with BitBucket

### DIFF
--- a/planex.spec
+++ b/planex.spec
@@ -14,6 +14,7 @@ Requires: mock
 Requires: python-argcomplete
 Requires: python-argparse
 Requires: python-setuptools
+Requires: python-requests
 Requires: rpm-build
 Requires: yum-plugin-priorities
 

--- a/planex/repository.py
+++ b/planex/repository.py
@@ -20,6 +20,7 @@ class Repository(object):
         self.dir_name = ''
         self.branch = None
         self.tag = None
+        self.commitish = None
         self.sha1 = None
         if self.url.netloc in self.parsers:
             self.parsers[self.url.netloc](self)
@@ -65,9 +66,15 @@ class Repository(object):
         if self.tag:
             option = '-t'
             ref = self.tag
-        else:
+        elif self.branch:
             option = '-h'
             ref = self.branch
+        elif self.commitish:
+            option = ''
+            ref = self.commitish
+        else:
+            self.sha1 = ''
+            return
 
         # Example command:
         # git ls-remote -t \
@@ -150,7 +157,7 @@ class Repository(object):
                 else:
                     self.branch = 'master'
             else:
-                self.tag = query
+                self.commitish = query
         else:
             self.branch = 'master'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 pep8
 pylint
 argcomplete
+requests

--- a/tests/data/bitbucket-repo.json
+++ b/tests/data/bitbucket-repo.json
@@ -4,7 +4,9 @@
 	"clone_URL": "ssh://git@code.citrite.net/~SIMONR/brocade-bna.git",
 	"branch": "master",
 	"tag": null,
+	"commitish": null,
 	"git_ls_remote_out": "7cdf99ff799b4bd1f33bcde2c79ac56e603f2c23\trefs/heads/master\n",
+	"requests_get_out": null,
 	"sha1": "7cdf99ff799b4bd1f33bcde2c79ac56e603f2c23"
     },
     {
@@ -12,7 +14,9 @@
 	"clone_URL": "ssh://git@code.citrite.net/XS/linux-firmware.git",
 	"branch": null,
 	"tag": "20160622",
+	"commitish": null,
 	"git_ls_remote_out": "dca884016afa9f954baa69e3e28b8f2aab3b6921\trefs/tags/20160622\n",
+	"requests_get_out": null,
 	"sha1": "dca884016afa9f954baa69e3e28b8f2aab3b6921"
     },
     {
@@ -20,15 +24,19 @@
 	"clone_URL": "ssh://git@code.citrite.net/XS/lvm2.git",
 	"branch": "xenserver_patches",
 	"tag": null,
+	"commitish": null,
 	"git_ls_remote_out": "dc69fe697517ce922de8dca822d75c9bb7b59b70\trefs/heads/xenserver_patches\n",
+	"requests_get_out": null,
 	"sha1": "dc69fe697517ce922de8dca822d75c9bb7b59b70"
     },
     {
 	"URL": "https://code.citrite.net/rest/archive/latest/projects/XS/repos/linux-4.x.pg/archive?at=b17a2301da0&format=tar#/kernel.patches.tar",
 	"clone_URL": "ssh://git@code.citrite.net/XS/linux-4.x.pg.git",
 	"branch": null,
-	"tag": "b17a2301da0",
+	"tag": null,
+	"commitish": "b17a2301da0",
 	"git_ls_remote_out": "",
-	"sha1": ""
+	"requests_get_out": {"id": "b17a2301da054897d134bd20b66a0c70ed5bc5a5"},
+	"sha1": "b17a2301da054897d134bd20b66a0c70ed5bc5a5"
     }
 ]

--- a/tests/test_bitbucket_repository.py
+++ b/tests/test_bitbucket_repository.py
@@ -17,12 +17,17 @@ class BasicTests(unittest.TestCase):
         with open("tests/data/bitbucket-repo.json") as fileh:
             self.data = json.load(fileh)
 
+    @mock.patch('planex.repository.requests.get')
     @mock.patch('planex.repository.git_ls_remote')
-    def test_urls(self, mock_git_ls_remote):
+    def test_urls(self, mock_git_ls_remote, mock_requests_get):
         for tcase in self.data:
             mock_git_ls_remote.return_value = tcase['git_ls_remote_out']
+            requests_response = mock.Mock()
+            requests_response.json.return_value = tcase['requests_get_out']
+            mock_requests_get.return_value = requests_response
             repo = planex.repository.Repository(tcase['URL'])
             self.assertEqual(repo.clone_url, tcase['clone_URL'])
             self.assertEqual(repo.branch, tcase['branch'])
             self.assertEqual(repo.tag, tcase['tag'])
+            self.assertEqual(repo.commitish, tcase['commitish'])
             self.assertEqual(repo.sha1, tcase['sha1'])


### PR DESCRIPTION
This change adds support for converting git 'commitish' references in to a full SHA1 using the BitBucket API. This allows partial sha1's to be specified in a spec / lnk file, and the manifest generation to resolve them to full references.

Unit tests updated to cover this scenario, and tested in a local container.

Note adds a requirement for python-requests - spec file updated to cover this.

