### PR TITLE
extract: Don't prepend package name to patch filename

### DIFF
--- a/planex/extract.py
+++ b/planex/extract.py
@@ -68,8 +68,7 @@ def rewrite_spec(spec_in, spec_fh, patches, patchnum):
             if not done and line.upper().startswith('SOURCE'):
                 for patch in patches:
                     patchnum += 1
-                    spec_fh.write("Patch%d: %%{name}-%s\n" %
-                                  (patchnum, patch))
+                    spec_fh.write("Patch%d: %s\n" % (patchnum, patch))
                 done = True
             spec_fh.write(line)
 
@@ -197,13 +196,7 @@ def main(argv):
                                 defines=macros)
         for path, url in spec.all_sources():
             if url.netloc == '':
-                if 'patchqueue' in link:
-                    # trim off prefix
-                    src_path = os.path.join(patch_dir,
-                                            url.path[len(spec.name()) + 1:])
-                else:
-                    src_path = os.path.join(patch_dir, url.path)
-
+                src_path = os.path.join(patch_dir, url.path)
                 if src_path not in tar.getnames():
                     src_path = os.path.join(tar_root, url.path)
                 extract_file(tar, src_path, path)

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -48,6 +48,6 @@ class BasicTests(unittest.TestCase):
         with open(outfile) as fh:
             spec = fh.read(4096).split('\n')
 
-        self.assertIn("Patch0: %{name}-first.patch", spec)
-        self.assertIn("Patch1: %{name}-second.patch", spec)
-        self.assertIn("Patch2: %{name}-third.patch", spec)
+        self.assertIn("Patch0: first.patch", spec)
+        self.assertIn("Patch1: second.patch", spec)
+        self.assertIn("Patch2: third.patch", spec)


### PR DESCRIPTION
This is no longer required as patches are extracted into
per-package source subdirectories.

Signed-off-by: Euan Harris <euan.harris@citrix.com>