### PR TITLE
Rewrite linking to centralize all patch queue handling and rewriting in planex-make-srpm

### DIFF
--- a/planex/Makefile.rules
+++ b/planex/Makefile.rules
@@ -63,7 +63,6 @@ $(TOPDIR):
 	@echo -n Populating build directory: $(TOPDIR)...
 	@mkdir -p $(TOPDIR)
 	@mkdir -p SPECS SOURCES
-	@ln -s ../SOURCES $(TOPDIR)/SOURCES
 	@ln -s ../mock $(TOPDIR)/mock
 	@mkdir $(TOPDIR)/RPMS
 	@mkdir $(TOPDIR)/SPECS

--- a/planex/Makefile.rules
+++ b/planex/Makefile.rules
@@ -103,8 +103,8 @@ MANIFESTS/%.json:
 	$(AT)$(FETCH) $(FETCH_FLAGS) $< $@
 
 # Fetch a patch tarball listed in a link file.
-.PRECIOUS: SOURCES/%/patches.tar
-SOURCES/%/patches.tar: SPECS/%.lnk
+.PRECIOUS: $(TOPDIR)/SOURCES/%/patches.tar
+$(TOPDIR)/SOURCES/%/patches.tar: SPECS/%.lnk
 	$(AT)$(FETCH) $(FETCH_FLAGS) $< $@
 
 
@@ -113,7 +113,7 @@ SOURCES/%/patches.tar: SPECS/%.lnk
 ############################################################################
 
 # Extract a spec file from a patch tarball.
-$(TOPDIR)/SPECS/%.spec: SPECS/%.lnk SOURCES/%/patches.tar
+$(TOPDIR)/SPECS/%.spec: SPECS/%.lnk $(TOPDIR)/SOURCES/%/patches.tar
 	$(AT)$(EXTRACT) $(EXTRACT_FLAGS) --output $@ --link $^
 
 

--- a/planex/Makefile.rules
+++ b/planex/Makefile.rules
@@ -169,7 +169,7 @@ $(DEPS): $(TOPDIR) $(wildcard $(PINSFILE) $(PINSDIR)/*.spec) \
 		$(patsubst SPECS/%.spec,$(TOPDIR)/SPECS/%.spec,$(wildcard SPECS/*.spec)) \
 		$(patsubst SPECS/%.lnk,$(TOPDIR)/SPECS/%.spec,$(wildcard SPECS/*.lnk))
 	@echo Updating dependencies...
-	$(AT)$(DEPEND) $(DEPEND_FLAGS) $(TOPDIR)/SPECS/*.spec > $@
+	$(AT)$(DEPEND) $(DEPEND_FLAGS) SPECS/*.lnk $(TOPDIR)/SPECS/*.spec > $@
 
 include $(DEPS)
 

--- a/planex/extract.py
+++ b/planex/extract.py
@@ -7,18 +7,14 @@ import json
 import logging
 import os
 import os.path
-import re
 import sys
 import tarfile
-
-from contextlib import closing
 
 import argcomplete
 
 from planex.util import add_common_parser_options
 from planex.util import setup_logging
 from planex.util import setup_sigint_handler
-import planex.spec
 
 
 def extract_file(tar, name_in, name_out):
@@ -32,59 +28,6 @@ def extract_file(tar, name_in, name_out):
     mem.name = os.path.basename(name_out)
     tar.extract(mem, os.path.dirname(name_out))
     os.utime(name_out, None)
-
-
-def parse_patchseries(series, guard=None):
-    """
-    Parse series file and return the list of patches
-    """
-    guard_re = re.compile(r'([\S]+)(\s#.*)?')
-
-    for line in series:
-        line = line.strip()
-        if not line or line.startswith('#'):
-            continue
-
-        match = guard_re.match(line)
-        if match.group(2):
-            gtype = match.group(2)[2]
-            guard_patch = match.group(2)[3:]
-
-            if gtype == '+' and guard != guard_patch:
-                continue
-            if gtype == '-' and guard == guard_patch:
-                continue
-
-        yield match.group(1)
-
-
-def rewrite_spec(spec_in, spec_fh, patches, patchnum):
-    """
-    Expand a patchqueue as a sequence of patches in a spec file
-    """
-    done = False
-    with open(spec_in) as fh_in:
-        for line in fh_in:
-            if not done and line.upper().startswith('SOURCE'):
-                for patch in patches:
-                    patchnum += 1
-                    spec_fh.write("Patch%d: %s\n" % (patchnum, patch))
-                done = True
-            spec_fh.write(line)
-
-
-def expand_patchqueue(spec_fh, spec, spec_in, tar, seriesfile):
-    """
-    Create a list of patches from a patchqueue and update the spec file
-    """
-    # Build a list of patches
-    with closing(tar.extractfile(seriesfile)) as series:
-        patches = list(parse_patchseries(series))
-
-    patchnum = spec.highest_patch()
-
-    # Rewrite the spec file to include the patches
-    rewrite_spec(spec_in, spec_fh, patches, patchnum)
 
 
 def archive_root(tar):
@@ -121,10 +64,6 @@ def parse_args_or_exit(argv=None):
                         help="Output spec file")
     parser.add_argument("-t", "--topdir", metavar="DIR", default=None,
                         help="Set rpmbuild toplevel directory [deprecated]")
-    parser.add_argument("--no-package-name-check", dest="check_package_names",
-                        action="store_false", default=True,
-                        help="Don't check that package name matches spec "
-                        "file name")
     parser.add_argument("-D", "--define", default=[], action="append",
                         help="--define='MACRO EXPR' define MACRO with "
                         "value EXPR")
@@ -136,7 +75,6 @@ def main(argv):
     """
     Main function.  Fetch sources directly or via a link file.
     """
-    # pylint: disable=R0914
 
     setup_sigint_handler()
     args = parse_args_or_exit(argv)
@@ -171,35 +109,9 @@ def main(argv):
             macros.insert(0, ('_topdir', args.topdir))
 
         with open(args.output, "w") as spec_fh:
-            check_names = args.check_package_names
-            spec = planex.spec.Spec(args.output + '.tmp',
-                                    check_package_name=check_names,
-                                    defines=macros)
-
             if 'branch' in link:
                 spec_fh.write("%%define branch %s\n" % link['branch'])
-
-            if 'patchqueue' in link:
-                patch_dir = os.path.join(tar_root, str(link['patchqueue']))
-                expand_patchqueue(spec_fh, spec, args.output + '.tmp',
-                                  tar, os.path.join(patch_dir, 'series'))
-            elif 'patches' in link:
-                patch_dir = os.path.join(tar_root, str(link['patches']))
-                copy_spec(args.output + '.tmp', spec_fh)
-            else:
-                sys.exit("%s: %s: Expected one of 'patchqueue' or 'patches'" %
-                         (sys.argv[0], args.link))
-
-        # Extract sources contained in the tarball
-        spec = planex.spec.Spec(args.output,
-                                check_package_name=args.check_package_names,
-                                defines=macros)
-        for path, url in spec.all_sources():
-            if url.netloc == '':
-                src_path = os.path.join(patch_dir, url.path)
-                if src_path not in tar.getnames():
-                    src_path = os.path.join(tar_root, url.path)
-                extract_file(tar, src_path, path)
+            copy_spec(args.output + '.tmp', spec_fh)
 
 
 def _main():

--- a/tests/test_depend.py
+++ b/tests/test_depend.py
@@ -16,7 +16,7 @@ class BasicTests(unittest.TestCase):
     # pylint: disable=R0904
     def setUp(self):
         rpm_defines = [("dist", ".el6"),
-                       ("_topdir", "."),
+                       ("_topdir", "_build"),
                        ("_sourcedir", "%_topdir/SOURCES/%name")]
         self.spec = planex.spec.Spec("tests/data/ocaml-cohttp.spec",
                                      defines=rpm_defines)
@@ -26,18 +26,21 @@ class BasicTests(unittest.TestCase):
 
         self.assertEqual(
             sys.stdout.getvalue(),
-            "./SRPMS/ocaml-cohttp-0.9.8-1.el6.src.rpm: "
-            "tests/data/ocaml-cohttp.spec "
-            "./SOURCES/ocaml-cohttp/ocaml-cohttp-0.9.8.tar.gz "
-            "./SOURCES/ocaml-cohttp/ocaml-cohttp-init "
-            "./MANIFESTS/ocaml-cohttp.json\n")
+            "_build/SRPMS/ocaml-cohttp-0.9.8-1.el6.src.rpm: "
+            "tests/data/ocaml-cohttp.spec\n"
+            "_build/SRPMS/ocaml-cohttp-0.9.8-1.el6.src.rpm: "
+            "./MANIFESTS/ocaml-cohttp.json\n"
+            "_build/SRPMS/ocaml-cohttp-0.9.8-1.el6.src.rpm: "
+            "_build/SOURCES/ocaml-cohttp/ocaml-cohttp-0.9.8.tar.gz\n"
+            "_build/SRPMS/ocaml-cohttp-0.9.8-1.el6.src.rpm: "
+            "SOURCES/ocaml-cohttp/ocaml-cohttp-init\n")
 
     def test_download_rpm_sources(self):
         planex.depend.download_rpm_sources(self.spec)
 
         self.assertEqual(
             sys.stdout.getvalue(),
-            "./SOURCES/ocaml-cohttp/ocaml-cohttp-0.9.8.tar.gz: "
+            "_build/SOURCES/ocaml-cohttp/ocaml-cohttp-0.9.8.tar.gz: "
             "tests/data/ocaml-cohttp.spec\n")
 
     def test_build_rpm_from_srpm(self):
@@ -45,8 +48,8 @@ class BasicTests(unittest.TestCase):
 
         self.assertEqual(
             sys.stdout.getvalue(),
-            "./RPMS/x86_64/ocaml-cohttp-devel-0.9.8-1.el6.x86_64.rpm: "
-            "./SRPMS/ocaml-cohttp-0.9.8-1.el6.src.rpm\n")
+            "_build/RPMS/x86_64/ocaml-cohttp-devel-0.9.8-1.el6.x86_64.rpm: "
+            "_build/SRPMS/ocaml-cohttp-0.9.8-1.el6.src.rpm\n")
 
     def test_buildrequires_for_rpm(self):
         # N.B. buildrequires_for_rpm only generates rules for other packages
@@ -62,7 +65,7 @@ class BasicTests(unittest.TestCase):
 
         self.assertEqual(
             sys.stdout.getvalue(),
-            "./RPMS/x86_64/ocaml-cohttp-devel-0.9.8-1.el6.x86_64.rpm: "
-            "./RPMS/x86_64/ocaml-uri-devel-1.6.0-1.el6.x86_64.rpm\n"
-            "./RPMS/x86_64/ocaml-cohttp-devel-0.9.8-1.el6.x86_64.rpm: "
-            "./RPMS/x86_64/ocaml-cstruct-devel-1.4.0-1.el6.x86_64.rpm\n")
+            "_build/RPMS/x86_64/ocaml-cohttp-devel-0.9.8-1.el6.x86_64.rpm: "
+            "_build/RPMS/x86_64/ocaml-uri-devel-1.6.0-1.el6.x86_64.rpm\n"
+            "_build/RPMS/x86_64/ocaml-cohttp-devel-0.9.8-1.el6.x86_64.rpm: "
+            "_build/RPMS/x86_64/ocaml-cstruct-devel-1.4.0-1.el6.x86_64.rpm\n")


### PR DESCRIPTION
 - The top level SOURCES directory is no longer symlinked in to _build, so source tarballs downloaded by planex-fetch are no longer mixed up with sources which come from the spec file repository.
 - patchqueues are no longer unpacked into SOURCES, removing the possibility of stale patches being left over from previous builds
 - All spec file manipulation now happens in planex-make-srpm's working directory.   The spec file in the SRPM is rewritten to include patches and to handle top level tarball directories which don't match rpmbuild's expectaitions.   The spec file in _build/SPECS is extracted from the patch queue unaltered and is only used by planex-depend.   planex-extract no longer rewrites files as it extracts them.
