### PR TITLE
Remove obsolete --topdir and --dist flags

### DIFF
--- a/planex/depend.py
+++ b/planex/depend.py
@@ -116,18 +116,12 @@ def parse_cmdline():
     parser.add_argument(
         "-P", "--pins-dir", help="Directory containing pin overlays")
     parser.add_argument(
-        "-d", "--dist", metavar="DIST", default=None,
-        help="distribution tag (used in RPM filenames) [deprecated]")
-    parser.add_argument(
         "-r", "--repos_path", metavar="DIR", default="repos",
         help='Local path to the repositories')
     parser.add_argument(
         "--no-package-name-check", dest="check_package_names",
         action="store_false", default=True,
         help="Don't check that package name matches spec file name")
-    parser.add_argument(
-        "-t", "--topdir", metavar="DIR", default=None,
-        help='Set rpmbuild toplevel directory [deprecated]')
     parser.add_argument(
         "-D", "--define", default=[], action="append",
         help="--define='MACRO EXPR' define MACRO with value EXPR")
@@ -161,15 +155,6 @@ def main():
         _err = [macro for macro in macros if len(macro) != 2]
         print "error: malformed macro passed to --define: %r" % _err
         sys.exit(1)
-
-    # When using deprecated arguments, we want them at the top of the
-    # macros list
-    if args.topdir is not None:
-        print "# warning: --topdir is deprecated"
-        macros.insert(0, ('_topdir', args.topdir))
-    if args.dist is not None:
-        print "# warning: --dist is deprecated"
-        macros.insert(1, ('dist', args.dist))
 
     pins = {}
     if args.pins_dir:

--- a/planex/extract.py
+++ b/planex/extract.py
@@ -62,8 +62,6 @@ def parse_args_or_exit(argv=None):
     parser.add_argument("-l", "--link", help="Link file")
     parser.add_argument("-o", "--output", metavar="SPEC",
                         help="Output spec file")
-    parser.add_argument("-t", "--topdir", metavar="DIR", default=None,
-                        help="Set rpmbuild toplevel directory [deprecated]")
     parser.add_argument("-D", "--define", default=[], action="append",
                         help="--define='MACRO EXPR' define MACRO with "
                         "value EXPR")
@@ -101,12 +99,6 @@ def main(argv):
             _err = [macro for macro in macros if len(macro) != 2]
             print "error: malformed macro passed to --define: %r" % _err
             sys.exit(1)
-
-        # When using deprecated arguments, we want them at the top of the
-        # macros list
-        if args.topdir is not None:
-            print "# warning: --topdir is deprecated"
-            macros.insert(0, ('_topdir', args.topdir))
 
         with open(args.output, "w") as spec_fh:
             if 'branch' in link:

--- a/planex/fetch.py
+++ b/planex/fetch.py
@@ -154,8 +154,6 @@ def parse_args_or_exit(argv=None):
     parser.add_argument('--retries', '-r',
                         help='Number of times to retry a failed download',
                         type=int, default=5)
-    parser.add_argument("-t", "--topdir", metavar="DIR", default=None,
-                        help='Set rpmbuild toplevel directory [deprecated]')
     parser.add_argument('--no-package-name-check', dest="check_package_names",
                         action="store_false", default=True,
                         help="Don't check that package name matches spec "
@@ -181,12 +179,6 @@ def fetch_sources(args):
         _err = [macro for macro in macros if len(macro) != 2]
         print "error: malformed macro passed to --define: %r" % _err
         sys.exit(1)
-
-    # When using deprecated arguments, we want them at the top of the
-    # macros list
-    if args.topdir is not None:
-        print "# warning: --topdir is deprecated"
-        macros.insert(0, ('_topdir', args.topdir))
 
     spec = planex.spec.Spec(args.spec_or_link,
                             check_package_name=args.check_package_names,

--- a/planex/makesrpm.py
+++ b/planex/makesrpm.py
@@ -35,12 +35,6 @@ def parse_args_or_exit(argv):
         "-D", "--define", default=[], action="append",
         help="--define='MACRO EXPR' define MACRO with value EXPR")
     parser.add_argument(
-        "--topdir", metavar="DIR", default=None,
-        help='Set rpmbuild toplevel directory [deprecated]')
-    parser.add_argument(
-        "--dist", metavar="DIST", default=None,
-        help="distribution tag (used in RPM filenames) [deprecated]")
-    parser.add_argument(
         "--keeptmp", action="store_true",
         help="keep temporary files")
     argcomplete.autocomplete(parser)
@@ -66,12 +60,6 @@ def rpmbuild(args, tmpdir, specfile):
     cmd = ['rpmbuild']
     if args.quiet:
         cmd.append('--quiet')
-    if args.topdir is not None:
-        cmd.append('--define')
-        cmd.append('_topdir %s' % args.topdir)
-    if args.dist is not None:
-        cmd.append('--define')
-        cmd.append('%%dist %s' % args.dist)
     for define in args.define:
         cmd.append('--define')
         cmd.append(define)


### PR DESCRIPTION
--topdir and --dist have been replaced by passing rpmbuild-style --define parameters directly