### PR TITLE
manifest: set up logging

### DIFF
--- a/planex/manifest.py
+++ b/planex/manifest.py
@@ -11,6 +11,7 @@ import argparse
 import argcomplete
 
 from planex.util import add_common_parser_options
+from planex.util import setup_logging
 from planex.spec import Spec
 from planex.repository import Repository
 
@@ -107,6 +108,7 @@ def main():
     """Entry point."""
 
     args = parse_cmdline()
+    setup_logging(args)
 
     spec = Spec(args.specfile_path)
 

--- a/planex/repository.py
+++ b/planex/repository.py
@@ -172,6 +172,7 @@ class Repository(object):
         path = self.url.path.split('/')
         url = "https://%s/rest/api/1.0/projects/%s/repos/%s/commits/%s" % \
             (self.url.netloc, path[5], path[7], commitish)
+        logging.debug("Fetching SHA1 using " + url)
         api_response = requests.get(url)
         api_response.raise_for_status()
         data = api_response.json()


### PR DESCRIPTION
Initialize logging so that --debug works. Also report the URL being
used to retrieve the SHA1 in repository.commitish_to_sha1_bitbucket().

Signed-off-by: Simon Rowe <simon.rowe@eu.citrix.com>