### PR TITLE
CP-18094: Fetch *.cpio Source archives

### DIFF
--- a/planex/Makefile.rules
+++ b/planex/Makefile.rules
@@ -96,8 +96,8 @@ MANIFESTS/%.json:
 ############################################################################
 
 # Fetch a source tarball listed in a spec file.
-.DELETE_ON_ERROR: %.tar %.tar.gz %.tar.xz %.tar.bz2 %.tgz %.tbz %.zip %.pdf
-%.tar %.tar.gz %.tar.xz %.tar.bz2 %.tgz %.tbz %.zip %.pdf:
+.DELETE_ON_ERROR: %.tar %.tar.gz %.tar.xz %.tar.bz2 %.tgz %.tbz %.zip %.pdf %.cpio
+%.tar %.tar.gz %.tar.xz %.tar.bz2 %.tgz %.tbz %.zip %.pdf %.cpio:
 	@echo [FETCH] $@
 	$(AT)$(FETCH) $(FETCH_FLAGS) $< $@
 


### PR DESCRIPTION
This is needed by the linux-guest-loader package.