### PR TITLE
Makefile.rules: Use correct implicit variable in copy

### DIFF
--- a/planex/Makefile.rules
+++ b/planex/Makefile.rules
@@ -79,8 +79,8 @@ $(TOPDIR):
 
 # Placeholder
 $(TOPDIR)/SPECS/%.spec: SPECS/%.spec
-	@mkdir -p $(dir $@)
-	@cp -lf $^ $@
+	$(AT) mkdir -p $(dir $@)
+	$(AT) cp -lf $< $@
 
 
 ############################################################################


### PR DESCRIPTION
$^ expands to all prerequisites, which confuses cp if
the target has several prerequisites.

Signed-off-by: Euan Harris <euan.harris@citrix.com>