### PR TITLE
Override generation tool

### DIFF
--- a/planex/cmd/override.py
+++ b/planex/cmd/override.py
@@ -27,9 +27,9 @@ def mkdir_p(path):
             raise exc
 
 
-def heuristical_is_spec_repo_root(xs_path):
+def heuristic_is_spec_repo_root(xs_path):
     """
-    Heuristical check for a spec repository root folder.
+    Heuristic check for a spec repository root folder.
     Looks for the presence of xs_path/.git, xs_path/SPECS and xs_path/mock.
     Raise and error if any of those is not present.
     """
@@ -37,8 +37,7 @@ def heuristical_is_spec_repo_root(xs_path):
     if not (os.path.exists("%s/.git" % xs_path) and
             os.path.exists("%s/SPECS" % xs_path) and
             os.path.exists("%s/mock" % xs_path)):
-        raise ValueError("Spec repository not found in the current path: %s"
-                         % xs_path)
+        raise Exception("Spec repository not found in %s" % xs_path)
 
 
 def is_spec(repo_path, package_name):
@@ -59,17 +58,20 @@ def is_spec(repo_path, package_name):
     raise Exception(err_str)
 
 
-def make_pin(xs_path, xs_repos, xs_branch, pinfile_dir, package_name, package_branch):
+def make_pin(xs_path, xs_branch, pinfile_dir, package_name, package_branch):
     """
     Return the pinfile path and a dict containing the content of the pinfile
     """
+
+    xs_repos = "repos"     # make it customisable?
+
     pinfile = {}
     pinfile['URL'] = "%s/%s" % (xs_repos, package_name)
     pinfile['commitish'] = package_branch
     pinfile['patchqueue'] = xs_branch
 
     if not is_spec(xs_path, package_name):
-        print "%s is a lnk: adding 'specfile' field to the override file" % package_name
+        print "%s is a lnk: adding 'specfile' field" % package_name
         pinfile['specfile'] = "%s.spec" % package_name
 
     pinfile_path = "%s/%s.pin" % (pinfile_dir, package_name)
@@ -106,11 +108,9 @@ def main(argv=None):
     args = parse_args_or_exit(argv)
 
     xs_path = os.getcwd()
-    heuristical_is_spec_repo_root(xs_path)
+    heuristic_is_spec_repo_root(xs_path)
 
     xs_branch = current_branch(xs_path)
-    # make it customisable?
-    xs_repos = "repos"
 
     pinfile_dir = "%s/%s/%s" % (xs_path, args.pinsdir, xs_branch)
     if not os.path.isdir(pinfile_dir):
@@ -120,12 +120,14 @@ def main(argv=None):
     package_branch = args.branch if args.branch is not None else "HEAD"
 
     for package_name in args.packages:
-        pinfile_path, pinfile = make_pin(xs_path, xs_repos, xs_branch, pinfile_dir,
+        pinfile_path, pinfile = make_pin(xs_path, xs_branch, pinfile_dir,
                                          package_name, package_branch)
         with open(pinfile_path, "w") as pin:
             json.dump(pinfile, pin)
 
-        print "Override file for %s saved in %s with the following content" % (package_name, pinfile_path)
+        print "Override file for %s saved in %s with the following content" % (
+            package_name, pinfile_path)
         print pinfile
 
-    print "To explicitly override the default transformer settings you can run make with PINSDIR=%s" % pinfile_dir
+    print "To explicitly override the default settings " \
+          "you can run make with PINSDIR=%s" % pinfile_dir

--- a/planex/cmd/override.py
+++ b/planex/cmd/override.py
@@ -110,6 +110,9 @@ def main(argv=None):
 
     args = parse_args_or_exit(argv)
 
+    if args.dry:
+        print "======= running in dry-run mode ======="
+
     xs_path = os.getcwd()
     heuristic_is_spec_repo_root(xs_path)
 

--- a/planex/cmd/override.py
+++ b/planex/cmd/override.py
@@ -16,7 +16,8 @@ from planex.util import add_common_parser_options
 
 def infer_current_xenserver_path(repo_name):
     """
-    Very hacky for now, cut the path to xenserver-specs and check the branch name.
+    Very hacky for now, cut the path to xenserver-specs
+    and check the branch name.
     """
 
     cwd = os.getcwd()
@@ -33,7 +34,8 @@ def parse_args_or_exit(argv=None):
     """
 
     parser = argparse.ArgumentParser(
-        description='Create an override file pointing to a repository in xenserver-specs/repos')
+        description="Create an override file pointing to a repository \
+                     in xenserver-specs/repos")
     add_common_parser_options(parser)
     parser.add_argument("reponame", metavar="REPO", help="repository nanme")
     parser.add_argument("branch", metavar="BRANCH", nargs="?",
@@ -49,7 +51,7 @@ def main(argv=None):
 
     args = parse_args_or_exit(argv)
 
-    #TODO: make it customisable
+    # TODO: make it customisable
     xs_path = infer_current_xenserver_path("xenserver-specs")
     xs_branch = current_branch(xs_path)
 

--- a/planex/cmd/override.py
+++ b/planex/cmd/override.py
@@ -1,0 +1,72 @@
+"""
+planex-override: generate override files pointing at local repos
+in xenserver-specs/repos/
+"""
+
+import errno
+import json
+import os
+
+import argparse
+import argcomplete
+
+from planex.git import current_branch
+from planex.util import add_common_parser_options
+
+
+def infer_current_xenserver_path(repo_name):
+    """
+    Very hacky for now, cut the path to xenserver-specs and check the branch name.
+    """
+
+    cwd = os.getcwd()
+    if repo_name in cwd:
+        path = cwd.split(repo_name)[0]
+        return os.path.normpath("/".join([path, repo_name]))
+
+    raise ValueError("%s not found in %s" % (repo_name, cwd))
+
+
+def parse_args_or_exit(argv=None):
+    """
+    Parse command line options
+    """
+
+    parser = argparse.ArgumentParser(
+        description='Create an override file pointing to a repository in xenserver-specs/repos')
+    add_common_parser_options(parser)
+    parser.add_argument("reponame", metavar="REPO", help="repository nanme")
+    parser.add_argument("branch", metavar="BRANCH", nargs="?",
+                        help="branch or tag name (defaults to HEAD)")
+    argcomplete.autocomplete(parser)
+    return parser.parse_args(argv)
+
+
+def main(argv=None):
+    """
+    Entry point
+    """
+
+    args = parse_args_or_exit(argv)
+
+    #TODO: make it customisable
+    xs_path = infer_current_xenserver_path("xenserver-specs")
+    xs_branch = current_branch(xs_path)
+
+    pinfile = {}
+    pinfile['URL'] = "repos/%s" % args.reponame
+    pinfile['commitish'] = args.branch if args.branch is not None else "HEAD"
+    pinfile['patchqueue'] = xs_branch
+
+    pinfile_dir = "%s/PINS/%s" % (xs_path, xs_branch)
+    pinfile_path = "%s/%s.pin" % (pinfile_dir, args.reponame)
+
+    print(pinfile, pinfile_dir, pinfile_path)
+
+    if not os.path.isdir(pinfile_dir):
+        print "Creating overrides directory %s" % pinfile_dir
+        os.mkdir(pinfile_dir)
+
+    print "Override file for %s saved in %s" % (args.reponame, pinfile_path)
+    with open(pinfile_path, "w") as pin:
+        json.dump(pinfile, pin)

--- a/planex/cmd/override.py
+++ b/planex/cmd/override.py
@@ -3,7 +3,6 @@ planex-override: generate override files pointing at local repos
 in xenserver-specs/repos/
 """
 
-import errno
 import json
 import os
 
@@ -11,20 +10,7 @@ import argparse
 import argcomplete
 
 from planex.git import current_branch
-from planex.util import add_common_parser_options
-
-
-def mkdir_p(path):
-    """
-    Like `mkdir -p path` but does not fail when the path is already present.
-    """
-    try:
-        os.makedirs(path)
-    except OSError as exc:
-        if exc.errno == errno.EEXIST and os.path.isdir(path):
-            pass
-        else:
-            raise exc
+from planex.util import add_common_parser_options, makedirs
 
 
 def heuristic_is_spec_repo_root(xs_path):
@@ -122,7 +108,7 @@ def main(argv=None):
     pinfile_dir = "%s/%s/%s" % (xs_path, args.pinsdir, xs_branch)
     if not args.dry:
         print "Creating overrides directory %s" % pinfile_dir
-        mkdir_p(pinfile_dir)
+        makedirs(pinfile_dir)
 
     for package_name in args.packages:
         pinfile_path, pinfile = make_pin(xs_path, xs_branch, pinfile_dir,

--- a/planex/cmd/override.py
+++ b/planex/cmd/override.py
@@ -64,6 +64,24 @@ def make_pin(xs_path, xs_branch, pinfile_dir, package_name, package_branch):
     return pinfile_path, pinfile
 
 
+def get_branch(branch, xs_path, package_name):
+    """
+    Return branch to use for the override
+    """
+    if branch is not None:
+        return branch
+
+    if is_spec(xs_path, package_name):
+        print "No custom branch specified, defaulting to HEAD for %s" \
+              % package_name
+        return "HEAD"
+
+    # else:
+    print "No custom branch specified, defaulting to guilt/master " \
+        "for %s because a patchqueue has been detected" % package_name
+    return "guilt/master"
+
+
 def parse_args_or_exit(argv=None):
     """
     Parse command line options
@@ -103,7 +121,6 @@ def main(argv=None):
     heuristic_is_spec_repo_root(xs_path)
 
     xs_branch = current_branch(xs_path)
-    package_branch = args.branch if args.branch is not None else "HEAD"
 
     pinfile_dir = "%s/%s/%s" % (xs_path, args.pinsdir, xs_branch)
     if not args.dry:
@@ -111,6 +128,7 @@ def main(argv=None):
         makedirs(pinfile_dir)
 
     for package_name in args.packages:
+        package_branch = get_branch(args.branch, xs_path, package_name)
         pinfile_path, pinfile = make_pin(xs_path, xs_branch, pinfile_dir,
                                          package_name, package_branch)
         if not args.dry:

--- a/planex/cmd/override.py
+++ b/planex/cmd/override.py
@@ -114,19 +114,19 @@ def main(argv=None):
     heuristic_is_spec_repo_root(xs_path)
 
     xs_branch = current_branch(xs_path)
+    package_branch = args.branch if args.branch is not None else "HEAD"
 
     pinfile_dir = "%s/%s/%s" % (xs_path, args.pinsdir, xs_branch)
-    if not os.path.isdir(pinfile_dir):
+    if not args.dry:
         print "Creating overrides directory %s" % pinfile_dir
         mkdir_p(pinfile_dir)
-
-    package_branch = args.branch if args.branch is not None else "HEAD"
 
     for package_name in args.packages:
         pinfile_path, pinfile = make_pin(xs_path, xs_branch, pinfile_dir,
                                          package_name, package_branch)
-        with open(pinfile_path, "w") as pin:
-            json.dump(pinfile, pin)
+        if not args.dry:
+            with open(pinfile_path, "w") as pin:
+                json.dump(pinfile, pin)
 
         print "Override file for %s saved in %s with the following content" % (
             package_name, pinfile_path)

--- a/planex/cmd/override.py
+++ b/planex/cmd/override.py
@@ -14,6 +14,19 @@ from planex.git import current_branch
 from planex.util import add_common_parser_options
 
 
+def mkdir_p(path):
+    """
+    Like `mkdir -p path` but does not fail when the path is already present.
+    """
+    try:
+        os.makedirs(path)
+    except OSError as exc:
+        if exc.errno == errno.EEXIST and os.path.isdir(path):
+            pass
+        else:
+            raise exc
+
+
 def infer_current_xenserver_path(repo_name):
     """
     Very hacky for now, cut the path to xenserver-specs
@@ -25,7 +38,43 @@ def infer_current_xenserver_path(repo_name):
         path = cwd.split(repo_name)[0]
         return os.path.normpath("/".join([path, repo_name]))
 
-    raise ValueError("%s not found in %s" % (repo_name, cwd))
+    raise ValueError("Base repository %s not found in the current path %s"
+                     % (repo_name, cwd))
+
+
+def is_spec(repo_path, package_name):
+    """
+    True if repo_path/SPECS/package_name is a spec file,
+    False if it is a link file,
+    Exception("package not present") otherwise
+    """
+    partial_file_path = "%s/SPECS/%s" % (repo_path, package_name)
+
+    if os.path.isfile("%s.spec" % partial_file_path):
+        return True
+    if os.path.isfile("%s.lnk" % partial_file_path):
+        return False
+
+    err_str = "Spec or link file for %s not present in %s/SPECS" % (
+        package_name, repo_path)
+    raise Exception(err_str)
+
+
+def make_pin(xs_path, xs_repos, xs_branch, pinfile_dir, package_name, package_branch):
+    """
+    Return the pinfile path and a dict containing the content of the pinfile
+    """
+    pinfile = {}
+    pinfile['URL'] = "%s/%s" % (xs_repos, package_name)
+    pinfile['commitish'] = package_branch
+    pinfile['patchqueue'] = xs_branch
+
+    if not is_spec(xs_path, package_name):
+        print "%s is a lnk: adding 'specfile' field to the override file" % package_name
+        pinfile['specfile'] = "%s.spec" % package_name
+
+    pinfile_path = "%s/%s.pin" % (pinfile_dir, package_name)
+    return pinfile_path, pinfile
 
 
 def parse_args_or_exit(argv=None):
@@ -35,11 +84,20 @@ def parse_args_or_exit(argv=None):
 
     parser = argparse.ArgumentParser(
         description="Create an override file pointing to a repository \
-                     in xenserver-specs/repos")
+                     in xenserver-specs/repos. The override automatically \
+                     points to the HEAD of the repository.")
     add_common_parser_options(parser)
-    parser.add_argument("reponame", metavar="REPO", help="repository nanme")
-    parser.add_argument("branch", metavar="BRANCH", nargs="?",
-                        help="branch or tag name (defaults to HEAD)")
+    parser.add_argument("packages", metavar="PKG", nargs="+",
+                        help="package name")
+    parser.add_argument("--pinsdir", default="PINS",
+                        help="use custom override folder (default to PINS)")
+    parser.add_argument("--baserepo", default="xenserver-specs",
+                        help="use custom base repository, \
+                              its name must be present in the path \
+                              (dafault to xenserver-specs)")
+    parser.add_argument("--branch", default=None,
+                        help="branch or tag name used for the override \
+                              (defaults to HEAD)")
     argcomplete.autocomplete(parser)
     return parser.parse_args(argv)
 
@@ -51,24 +109,25 @@ def main(argv=None):
 
     args = parse_args_or_exit(argv)
 
-    # TODO: make it customisable
-    xs_path = infer_current_xenserver_path("xenserver-specs")
+    xs_path = infer_current_xenserver_path(args.baserepo)
     xs_branch = current_branch(xs_path)
+    # make it customisable?
+    xs_repos = "repos"
 
-    pinfile = {}
-    pinfile['URL'] = "repos/%s" % args.reponame
-    pinfile['commitish'] = args.branch if args.branch is not None else "HEAD"
-    pinfile['patchqueue'] = xs_branch
-
-    pinfile_dir = "%s/PINS/%s" % (xs_path, xs_branch)
-    pinfile_path = "%s/%s.pin" % (pinfile_dir, args.reponame)
-
-    print(pinfile, pinfile_dir, pinfile_path)
-
+    pinfile_dir = "%s/%s/%s" % (xs_path, args.pinsdir, xs_branch)
     if not os.path.isdir(pinfile_dir):
         print "Creating overrides directory %s" % pinfile_dir
-        os.mkdir(pinfile_dir)
+        mkdir_p(pinfile_dir)
 
-    print "Override file for %s saved in %s" % (args.reponame, pinfile_path)
-    with open(pinfile_path, "w") as pin:
-        json.dump(pinfile, pin)
+    package_branch = args.branch if args.branch is not None else "HEAD"
+
+    for package_name in args.packages:
+        pinfile_path, pinfile = make_pin(xs_path, xs_repos, xs_branch, pinfile_dir,
+                                         package_name, package_branch)
+        with open(pinfile_path, "w") as pin:
+            json.dump(pinfile, pin)
+
+        print "Override file for %s saved in %s with the following content" % (package_name, pinfile_path)
+        print pinfile
+
+    print "To explicitly override the default transformer settings you can run make with PINSDIR=%s" % pinfile_dir

--- a/planex/cmd/override.py
+++ b/planex/cmd/override.py
@@ -84,18 +84,21 @@ def parse_args_or_exit(argv=None):
     """
 
     parser = argparse.ArgumentParser(
-        description="Create an override file pointing to a repository \
-                     in $CWD/repos. The override automatically \
-                     points to the HEAD of the repository. You must run \
-                     this tool from the root of a spec repository.")
+        description="Create an override file pointing to a repository "
+                    "in $CWD/repos. The override automatically "
+                    "points to the HEAD of the repository. You must run "
+                    "this tool from the root of a spec repository.")
     add_common_parser_options(parser)
     parser.add_argument("packages", metavar="PKG", nargs="+",
                         help="package name")
     parser.add_argument("--pinsdir", default="PINS",
                         help="use custom override folder (default to PINS)")
     parser.add_argument("--branch", default=None,
-                        help="branch or tag name used for the override \
-                              (defaults to HEAD)")
+                        help="branch or tag name used for the override "
+                             "(defaults to HEAD)")
+    parser.add_argument("--dry-run", dest="dry", action="store_true",
+                        help="perform a dry-run only showing the "
+                             "performed steps")
     argcomplete.autocomplete(parser)
     return parser.parse_args(argv)
 

--- a/planex/cmd/pin.py
+++ b/planex/cmd/pin.py
@@ -1,6 +1,6 @@
 """
-planex-override: generate override files pointing at local repos
-in xenserver-specs/repos/
+planex-pin: generate pin files pointing at local repos
+in xenserver-specs/repos/ to override the spec/lnk
 """
 
 import json
@@ -66,7 +66,7 @@ def make_pin(xs_path, xs_branch, pinfile_dir, package_name, package_branch):
 
 def get_branch(branch, xs_path, package_name):
     """
-    Return branch to use for the override
+    Return branch to use for the pin
     """
     if branch is not None:
         return branch
@@ -88,18 +88,17 @@ def parse_args_or_exit(argv=None):
     """
 
     parser = argparse.ArgumentParser(
-        description="Create an override file pointing to a repository "
-                    "in $CWD/repos. The override automatically "
-                    "points to the HEAD of the repository. You must run "
+        description="Create a .pin file pointing to a repository "
+                    "in $CWD/repos. You must run "
                     "this tool from the root of a spec repository.")
     add_common_parser_options(parser)
     parser.add_argument("packages", metavar="PKG", nargs="+",
                         help="package name")
     parser.add_argument("--pinsdir", default="PINS",
-                        help="use custom override folder (default to PINS)")
+                        help="use custom pin folder (default to PINS)")
     parser.add_argument("--branch", default=None,
-                        help="branch or tag name used for the override "
-                             "(defaults to HEAD)")
+                        help="branch, hash or tag name to specify "
+                             "the source tree to compile (defaults to HEAD)")
     parser.add_argument("--dry-run", dest="dry", action="store_true",
                         help="perform a dry-run only showing the "
                              "performed steps")
@@ -124,7 +123,7 @@ def main(argv=None):
 
     pinfile_dir = "%s/%s/%s" % (xs_path, args.pinsdir, xs_branch)
     if not args.dry:
-        print "Creating overrides directory %s" % pinfile_dir
+        print "Creating pins directory %s" % pinfile_dir
         makedirs(pinfile_dir)
 
     for package_name in args.packages:
@@ -135,7 +134,7 @@ def main(argv=None):
             with open(pinfile_path, "w") as pin:
                 json.dump(pinfile, pin)
 
-        print "Override file for %s saved in %s with the following content" % (
+        print "Pin file for %s saved in %s with the following content" % (
             package_name, pinfile_path)
         print pinfile
 

--- a/planex/git.py
+++ b/planex/git.py
@@ -87,7 +87,8 @@ def current_branch(repo):
     """
     Return the name of the current branch on repo. Requires git 1.7+.
     """
-    return run(["git", "-C", "%s" % repo, "rev-parse", "--abbrev-ref", "HEAD"])['stdout'].strip()
+    return run(["git", "-C", "%s" % repo, "rev-parse",
+                "--abbrev-ref", "HEAD"])['stdout'].strip()
 
 
 def format_patch(repo, startref, endref, target_dir):

--- a/planex/git.py
+++ b/planex/git.py
@@ -87,7 +87,7 @@ def current_branch(repo):
     """
     Return the name of the current branch on repo. Requires git 1.7+.
     """
-    return run(["git", "-C", "%s" % repo, "rev-parse",
+    return run(["git", "--work-tree=%s" % repo, "rev-parse",
                 "--abbrev-ref", "HEAD"])['stdout'].strip()
 
 

--- a/planex/git.py
+++ b/planex/git.py
@@ -83,6 +83,13 @@ def tags(repo):
     return run(["git", "--git-dir=%s" % dotgitdir, "tag"])['stdout'].split()
 
 
+def current_branch(repo):
+    """
+    Return the name of the current branch on repo. Requires git 1.7+.
+    """
+    return run(["git", "-C", "%s" % repo, "rev-parse", "--abbrev-ref", "HEAD"])['stdout'].strip()
+
+
 def format_patch(repo, startref, endref, target_dir):
     """
     Write patches from ref to HEAD out to target_dir.

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(name='planex',
               'planex-init = planex.cmd.init:main',
               'planex-make-srpm = planex.cmd.makesrpm:main',
               'planex-manifest = planex.cmd.manifest:main',
+              'planex-override = planex.cmd.override:main',
               'planex-patchqueue = planex.cmd.patchqueue:main'
           ]
       })

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(name='planex',
               'planex-init = planex.cmd.init:main',
               'planex-make-srpm = planex.cmd.makesrpm:main',
               'planex-manifest = planex.cmd.manifest:main',
-              'planex-override = planex.cmd.override:main',
+              'planex-pin = planex.cmd.pin:main',
               'planex-patchqueue = planex.cmd.patchqueue:main'
           ]
       })


### PR DESCRIPTION
This PR introduces a first version of `planex-override`, a tool to automatically generate `.pin` files to override selected packages in `SPECS` with custom local repositories.

The tool is meant to be explicit, explaining the step performed and showing the generated output when invoked.

It might be worth to add ~~a `--dry-run` flag and~~ some unit tests as next step.