### PR TITLE
makesrpm, mock, patchqueue: Use identifiable prefixes for temporary directories

### DIFF
--- a/planex/cmd/makesrpm.py
+++ b/planex/cmd/makesrpm.py
@@ -118,7 +118,7 @@ def main(argv=None):
         argv = sys.argv[1:]
 
     args = parse_args_or_exit(argv)
-    tmpdir = tempfile.mkdtemp()
+    tmpdir = tempfile.mkdtemp(prefix="px-srpm-")
 
     try:
         specfile = populate_working_directory(tmpdir, args.spec, args.link,

--- a/planex/cmd/mock.py
+++ b/planex/cmd/mock.py
@@ -115,7 +115,7 @@ def main(argv=None):
 
     args = parse_args_or_exit(argv)
 
-    tmpdir = tempfile.mkdtemp()
+    tmpdir = tempfile.mkdtemp(prefix="px-mock-")
     try:
         config_in = os.path.join(args.configdir, args.root + ".cfg")
         config_out = os.path.join(tmpdir, args.root + ".cfg")

--- a/planex/cmd/patchqueue.py
+++ b/planex/cmd/patchqueue.py
@@ -107,7 +107,7 @@ def main(argv=None):
             start_tag = "v%s" % start_tag
 
     try:
-        tmpdir = tempfile.mkdtemp()
+        tmpdir = tempfile.mkdtemp(prefix="px-pq-")
         assemble_patchqueue(tmpdir, link, repo, start_tag, end_tag)
         assemble_extra_sources(tmpdir, link,
                                spec.local_sources(), spec.local_patches())


### PR DESCRIPTION
This makes it easier to tell if a utility is leaking temporary directories.