### PR TITLE
Initial version of new clone sources script which supports Jenkins CI

### DIFF
--- a/planex/Makefile.rules
+++ b/planex/Makefile.rules
@@ -7,6 +7,7 @@ DIST ?= .el6
 TOPDIR ?= _build
 DEPS = $(TOPDIR)/deps
 PINSDIR ?= PINS
+REPOSDIR ?= repos
 RPM_DEFINES ?= --define="_topdir $(TOPDIR)" \
                --define="dist $(DIST)" \
                $(RPM_EXTRA_DEFINES)
@@ -47,7 +48,7 @@ MANIFEST ?= planex-manifest
 MANIFEST_FLAGS ?=
 
 PATCHQUEUE ?= planex-patchqueue
-PATCHQUEUE_FLAGS ?=
+PATCHQUEUE_FLAGS ?= --repos $(REPOSDIR)
 
 ifdef QUIET
 AT = @

--- a/planex/cmd/clone.py
+++ b/planex/cmd/clone.py
@@ -1,0 +1,74 @@
+"""
+planex-clone: Checkout sources referred to by a pin file
+"""
+
+from string import Template
+import argparse
+import os
+import subprocess
+
+from planex.link import Link
+import planex.util as util
+
+
+def parse_args_or_exit(argv=None):
+    """
+    Parse command line options
+    """
+    parser = argparse.ArgumentParser(description='Clone sources')
+    parser.add_argument("-P", "--pins-dir", default="PINS",
+                        help="Directory containing pin overlays")
+    parser.add_argument("--jenkins", action="store_true",
+                        help="Print Jenkinsfile fragment")
+    parser.add_argument("--credentials", metavar="CREDS", default="",
+                        help="Credentials")
+    parser.add_argument(
+        "-r", "--repos", metavar="DIR", default="repos",
+        help='Local path to the repositories')
+    parser.add_argument("pins", metavar="PINS", nargs="+", help="pin file")
+    return parser.parse_args(argv)
+
+
+CHECKOUT_TEMPLATE = Template("""checkout poll: true,
+         scm:[$$class: 'GitSCM',
+              branches: [[name: '$branch']],
+              extensions: [[$$class: 'RelativeTargetDirectory',
+                            relativeTargetDir: '$checkoutdir'],
+                           [$$class: 'LocalBranch']],
+              userRemoteConfigs: [
+                [credentialsId: '$credentials',
+                 url: '$url']]]
+""")
+
+
+def clone(url, destination, branch="master"):
+    """Clone repository"""
+    cmd = ['git', 'clone', '--branch', branch, url, destination]
+    subprocess.check_call(cmd)
+
+
+def main(argv=None):
+    """
+    Entry point
+    """
+    args = parse_args_or_exit(argv)
+
+    for pinpath in args.pins:
+        pin = Link(pinpath)
+        reponame = os.path.basename(pin.url).rsplit(".git")[0]
+        checkoutdir = os.path.join(args.repos, reponame)
+
+        if args.jenkins:
+            print 'echo "Cloning %s"' % pin.url
+            print CHECKOUT_TEMPLATE.substitute(url=pin.url,
+                                               branch=pin.commitish,
+                                               checkoutdir=checkoutdir,
+                                               credentials=args.credentials)
+
+        else:
+            print "Cloning %s" % pin.url
+            util.makedirs(os.path.dirname(checkoutdir))
+            clone(pin.url, checkoutdir, pin.commitish)
+
+if __name__ == "__main__":
+    main()

--- a/planex/cmd/patchqueue.py
+++ b/planex/cmd/patchqueue.py
@@ -7,6 +7,7 @@ import argparse
 import os
 import shutil
 import tempfile
+from urlparse import urlparse
 
 import argcomplete
 
@@ -26,6 +27,8 @@ def parse_args_or_exit(argv=None):
     util.add_common_parser_options(parser)
     parser.add_argument("link", metavar="LINK", help="link file")
     parser.add_argument("tarball", metavar="TARBALL", help="tarball")
+    parser.add_argument("--repos", default="repos",
+                        help="Local repository directory")
     parser.add_argument("--keeptmp", action="store_true",
                         help="Do not clean up working directory")
     argcomplete.autocomplete(parser)
@@ -88,6 +91,13 @@ def main(argv=None):
     end_tag = link.commitish
     if end_tag is None:
         end_tag = "HEAD"
+
+    # If the repository URL in the link is remote, look for a
+    # local clone in repos (without a .git suffix)
+    url = urlparse(repo)
+    if url.scheme:
+        reponame = os.path.basename(url.path).rsplit(".git")[0]
+        repo = os.path.join(args.repos, reponame)
 
     # Start tag is based on the version specified in the spec file,
     # but the tag name may be slightly different (v1.2.3 rather than 1.2.3)

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ setup(name='planex',
       entry_points={
           'console_scripts': [
               'planex-build-mock = planex.cmd.mock:main',
+              'planex-clone= planex.cmd.clone:main',
               'planex-clone-sources = planex.cmd.clonesources:main',
               'planex-depend = planex.cmd.depend:main',
               'planex-extract = planex.cmd.extract:main',


### PR DESCRIPTION
This utility will replace the existing planex-clone-sources script.
The existing script tries clones repositories with patch queues, parsing
the tarball HTTP URLs in specs and links, constructing appropriate Git
URLs and fetching them.   The new script only clones pinned repositories -
generating new pin configurations will be handle by a separate script.
The new script adds the ability to print a fragment of Groovy code which
can be included in a Jenkinsfile to tell Jenkins to monitor and fetch a
pinned repository automatically.

This work allows us to set up Jenkins CI jobs for working branches and
have Jenkins build new changes automatically as they are pushed to 
pinned repositories.