### PR TITLE
Rework mock subprocesses

### DIFF
--- a/planex/cmd/mock.py
+++ b/planex/cmd/mock.py
@@ -49,19 +49,18 @@ def mock(args, tmp_config_dir, defaults):
     """
     cmd = ['mock']
     cmd += ["--uniqueext", uuid4().hex]
+    cmd += ['--configdir', tmp_config_dir]
+
     if args.quiet:
-        cmd.append('--quiet')
-    for define in args.define:
-        cmd.append('--define')
-        cmd.append(define)
-    cmd.append('--configdir')
-    cmd.append(tmp_config_dir)
+        cmd += ['--quiet']
     if args.root is not None:
-        cmd.append('--root')
-        cmd.append(args.root)
+        cmd += ['--root', args.root]
     if args.resultdir is not None:
-        cmd.append("--resultdir")
-        cmd.append(args.resultdir)
+        cmd += ["--resultdir", args.resultdir]
+
+    for define in args.define:
+        cmd += ['--define', define]
+
     cmd.extend(defaults)
     cmd.extend(args.srpms)
     subprocess.check_call(cmd)
@@ -76,7 +75,7 @@ def createrepo(pkg_dir, metadata_dir, quiet=False):
     cmd += ['--outputdir=%s' % metadata_dir]
     cmd += [pkg_dir]
     if quiet:
-        cmd.append('--quiet')
+        cmd += ['--quiet']
     subprocess.check_call(cmd)
 
 

--- a/planex/cmd/mock.py
+++ b/planex/cmd/mock.py
@@ -43,7 +43,7 @@ def parse_args_or_exit(argv=None):
     return parser.parse_args(argv)
 
 
-def mock(args, tmp_config_dir, defaults):
+def mock(args, tmp_config_dir, *extra_params):
     """
     Return mock command line and arguments
     """
@@ -61,8 +61,7 @@ def mock(args, tmp_config_dir, defaults):
     for define in args.define:
         cmd += ['--define', define]
 
-    cmd.extend(defaults)
-    cmd.extend(args.srpms)
+    cmd.extend(extra_params)
     subprocess.check_call(cmd)
 
 
@@ -107,10 +106,6 @@ def main(argv=None):
     Entry point
     """
 
-    defaults = [
-        "--rebuild"
-    ]
-
     args = parse_args_or_exit(argv)
 
     tmpdir = tempfile.mkdtemp(prefix="px-mock-")
@@ -126,7 +121,7 @@ def main(argv=None):
         shutil.copy2(os.path.join(args.configdir, "site-defaults.cfg"),
                      os.path.join(tmpdir, "site-defaults.cfg"))
 
-        mock(args, tmpdir, defaults)
+        mock(args, tmpdir, "--rebuild", *args.srpms)
 
     except subprocess.CalledProcessError as cpe:
         sys.exit(cpe.returncode)

--- a/planex/cmd/mock.py
+++ b/planex/cmd/mock.py
@@ -109,7 +109,6 @@ def main(argv=None):
 
     defaults = [
         "--uniqueext", uuid4().hex,
-        "--disable-plugin", "package_state",
         "--rebuild"
     ]
 

--- a/planex/cmd/mock.py
+++ b/planex/cmd/mock.py
@@ -48,6 +48,7 @@ def mock(args, tmp_config_dir, defaults):
     Return mock command line and arguments
     """
     cmd = ['mock']
+    cmd += ["--uniqueext", uuid4().hex]
     if args.quiet:
         cmd.append('--quiet')
     for define in args.define:
@@ -108,7 +109,6 @@ def main(argv=None):
     """
 
     defaults = [
-        "--uniqueext", uuid4().hex,
         "--rebuild"
     ]
 


### PR DESCRIPTION
Rework subprocess handling in the planex-build-mock command in preparation for adding --init and --cleanup options.