### PR TITLE
Add option to pre-warm the mock cache before building

### DIFF
--- a/planex/Makefile.rules
+++ b/planex/Makefile.rules
@@ -164,7 +164,7 @@ $(TOPDIR)/SPECS/%.spec: SPECS/%.lnk $(TOPDIR)/SOURCES/%/patches.tar
 # to find and install it.
 %.rpm:
 	@echo [MOCK] $<
-	$(AT)$(MOCK) $(MOCK_FLAGS) $<
+	$(AT)$(MOCK) $(MOCK_FLAGS) --rebuild $<
 
 
 ############################################################################


### PR DESCRIPTION
When mock is first run, it builds a chroot image by downloading
and installing the RPMs specified in the 'chroot_setup_command' in
mock/default.cfg and saving the image as a tarball.   If several mock runs
are started at the same time and no root cache exists, they will all start
building one and will overwrite each others' tarballs as they complete.
This can lead to the root tarball being regenerated several times in the
early phase of a concurrent build.  To avoid this, we can call 'mock
init' before starting the build.  This populates the root cache once,
and the actual build jobs all use this cache rather than rebuilding it.
