### PR TITLE
Makefile.rules: Define variables for mock config directory and chroot…

### DIFF
--- a/planex/Makefile.rules
+++ b/planex/Makefile.rules
@@ -11,6 +11,8 @@ REPOSDIR ?= repos
 RPM_DEFINES ?= --define="_topdir $(TOPDIR)" \
                --define="dist $(DIST)" \
                $(RPM_EXTRA_DEFINES)
+MOCK_CONFIGDIR ?= /etc/mock
+MOCK_ROOT ?= default
 
 # Dependencies are not included when we are only cleaning as they may
 # have to be rebuilt and it makes no sense to do that when we know we are
@@ -38,7 +40,8 @@ CREATEREPO_FLAGS ?= ${QUIET+--quiet}
 
 MOCK ?= planex-build-mock
 MOCK_FLAGS ?= ${QUIET+--quiet} \
-              --configdir=mock \
+              --configdir=$(MOCK_CONFIGDIR) \
+              --root=$(MOCK_ROOT) \
               --resultdir=$(dir $@)
 
 DEPEND ?= planex-depend


### PR DESCRIPTION
… name

This makes it possible to build in a different chroot by overriding
these variables on the command line.

Signed-off-by: Euan Harris <euan.harris@citrix.com>