### PR TITLE
patchqueue: Produce a single patch rather than a whole series

### DIFF
--- a/planex/cmd/patchqueue.py
+++ b/planex/cmd/patchqueue.py
@@ -51,10 +51,12 @@ def assemble_patchqueue(tmpdir, link, repo, start_tag, end_tag):
     """
     patchqueue = os.path.join(tmpdir, link.patchqueue)
     os.makedirs(patchqueue)
-    patches = git.format_patch(repo, start_tag, end_tag, patchqueue)
+    patch = git.diff(repo, start_tag, end_tag)
+    patchname = "development.patch"
+    with open(os.path.join(patchqueue, patchname), "w") as patchfp:
+        patchfp.write(patch)
     with open(os.path.join(patchqueue, "series"), "w") as series:
-        for patch in patches:
-            series.write(os.path.basename(patch) + "\n")
+        series.write(patchname + "\n")
 
 
 def assemble_extra_sources(tmpdir, link, sources, patches):

--- a/planex/git.py
+++ b/planex/git.py
@@ -100,3 +100,15 @@ def format_patch(repo, startref, endref, target_dir):
     res = run(["git", "--git-dir=%s" % dotgitdir, "format-patch",
                "--no-renames", commit_range, "--output-directory", target_dir])
     return res['stdout'].split()
+
+
+def diff(repo, startref, endref):
+    """
+    Returns the diff between startref and endref as a string.
+    """
+    dotgitdir = dotgitdir_of_path(repo)
+
+    commit_range = "%s..%s" % (startref, endref)
+    res = run(["git", "--git-dir=%s" % dotgitdir, "diff", "--no-renames",
+               startref, endref])
+    return res['stdout']


### PR DESCRIPTION
Instead of using git-format-patch to produce a series of patches, use
git-diff to produce a single patch between the two refs. Using
git-format-patch is not appropriate because it is intended as a way of
emailing linear patch series and therefore doesn't work properly with
complex history.

Signed-off-by: Ross Lagerwall <ross.lagerwall@citrix.com>