### PR TITLE
Planex clone improvements

### DIFF
--- a/planex/cmd/clone.py
+++ b/planex/cmd/clone.py
@@ -43,6 +43,14 @@ CHECKOUT_TEMPLATE = Template("""checkout poll: true,
 """)
 
 
+def clone_jenkins(url, destination, commitish, credentials):
+    """Print Jenkinsfile fragment to clone repository"""
+    print CHECKOUT_TEMPLATE.substitute(url=url,
+                                       branch=commitish,
+                                       checkoutdir=destination,
+                                       credentials=credentials)
+
+
 def clone(url, destination, commitish):
     """Clone repository"""
     repo = git.Repo.clone_from(url, destination)
@@ -76,10 +84,7 @@ def main(argv=None):
 
         if args.jenkins:
             print 'echo "Cloning %s"' % pin.url
-            print CHECKOUT_TEMPLATE.substitute(url=pin.url,
-                                               branch=pin.commitish,
-                                               checkoutdir=checkoutdir,
-                                               credentials=args.credentials)
+            clone_jenkins(pin.url, checkoutdir, pin.commitish, args.credentials)
 
         else:
             print "Cloning %s" % pin.url

--- a/planex/cmd/clone.py
+++ b/planex/cmd/clone.py
@@ -120,7 +120,3 @@ def main(argv=None):
                 # Push patchqueue
                 subprocess.check_call(['guilt', 'push', '--all'],
                                       cwd=base_repo.working_dir)
-
-
-if __name__ == "__main__":
-    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 argcomplete
 argparse
+gitpython
 requests


### PR DESCRIPTION
* Make `planex-clone` handle structured branch names containing slashes.   This is needed for patchqueues, where the patchqueue must appear in a subdirectory matching the current branch name under .git/patches
* Make `planex-clone` create local branches when the upstream commitish does not point to a branch.