### PR TITLE
Pass --verbose if --quiet is not supplied so that logs are produced

### DIFF
--- a/planex/cmd/mock.py
+++ b/planex/cmd/mock.py
@@ -51,12 +51,15 @@ def mock(args, tmp_config_dir, *extra_params):
     """
     Return mock command line and arguments
     """
+    print "Mock args are %s" % args
     cmd = ['mock']
     cmd += ["--uniqueext", uuid4().hex]
     cmd += ['--configdir', tmp_config_dir]
 
     if args.quiet:
         cmd += ['--quiet']
+    else:
+        cmd += ['--verbose']
     if args.root is not None:
         cmd += ['--root', args.root]
     if args.resultdir is not None:


### PR DESCRIPTION
Log inside docker with concurrent builds and --output-sync=target