### PR TITLE
Docker: Pass SSH_AUTH_SOCK through to sudo session in container

### DIFF
--- a/docker/entry.sh
+++ b/docker/entry.sh
@@ -18,8 +18,4 @@ useradd build --groups mock,wheel \
               --no-create-home    \
               --non-unique
 
-if [ -z "$1" ]; then
-    exec sudo -u build -i SSH_AUTH_SOCK=$SSH_AUTH_SOCK
-else
-    exec sudo -u build -i SSH_AUTH_SOCK=$SSH_AUTH_SOCK "$@"
-fi
+exec sudo -u build -i SSH_AUTH_SOCK=$SSH_AUTH_SOCK $@

--- a/docker/entry.sh
+++ b/docker/entry.sh
@@ -19,7 +19,7 @@ useradd build --groups mock,wheel \
               --non-unique
 
 if [ -z "$1" ]; then
-    exec su - build
+    exec sudo -u build -i SSH_AUTH_SOCK=$SSH_AUTH_SOCK
 else
-    exec su - build -c "$@"
+    exec sudo -u build -i SSH_AUTH_SOCK=$SSH_AUTH_SOCK "$@"
 fi

--- a/docker/planex-container
+++ b/docker/planex-container
@@ -15,6 +15,8 @@ docker pull $PLANEX_CONTAINER
 docker run \
   --privileged \
   --rm -i -t \
+  -e SSH_AUTH_SOCK \
+  -v $(dirname $SSH_AUTH_SOCK):$(dirname $SSH_AUTH_SOCK) \
   -v ${PWD}/_obj/var/cache/mock:/var/cache/mock \
   -v ${PWD}/_obj/var/cache/yum:/var/cache/yum \
   -v ${PWD}:/build \


### PR DESCRIPTION
Cloning repositories over ssh relies on having access to credentials.
Mount the SSH_AUTH_SOCK into the container as a volume and pass the
SSH_AUTH_SOCK environment variable through.   To do this, we need
to use sudo rather than su to become the build user, as sudo allows
us to set individual environment variables whereas for su environment
preservation is all-or-nothing.

Signed-off-by: Euan Harris <euan.harris@citrix.com>