### PR TITLE
Add a check that a spec has %autosetup with a -p1 argument when applying patches

### DIFF
--- a/planex/patchqueue.py
+++ b/planex/patchqueue.py
@@ -7,6 +7,11 @@ import re
 import planex.tarball
 
 
+class SpecMissingAutosetup(Exception):
+    """Exception raised if the spec file is missing %autosetup -p1"""
+    pass
+
+
 class Patchqueue(object):
     """Represents a patchqueue archive"""
     def __init__(self, filename, branch="master"):

--- a/planex/patchqueue.py
+++ b/planex/patchqueue.py
@@ -105,4 +105,11 @@ def expand_patchqueue(spec, series):
     """
     patches = list(series)
     patchnum = spec.highest_patch()
+    found_autosetup = False
+    for line in spec.spectext:
+        if line.startswith("%autosetup") and "-p1" in line:
+            found_autosetup = True
+            break
+    if not found_autosetup:
+        raise SpecMissingAutosetup()
     return rewrite_spec(spec, patches, patchnum)

--- a/tests/data/manifest/branding-xenserver.spec
+++ b/tests/data/manifest/branding-xenserver.spec
@@ -13,7 +13,7 @@ Requires: python
 Files containing platform and product versioning, EULA etc.
 
 %prep
-%autosetup
+%autosetup -p1
 
 %install
 %{__make} -f Citrix/XenServer/Makefile install DESTDIR=%{buildroot}

--- a/tests/test_patchqueue.py
+++ b/tests/test_patchqueue.py
@@ -41,9 +41,16 @@ class BasicTests(unittest.TestCase):
         self.assertIn("patch_with_a_negative_guard", applied)
 
     def test_rewrite_spec(self):
-        spec = Spec("tests/data/ocaml-uri.spec", check_package_name=False)
+        spec = Spec("tests/data/manifest/branding-xenserver.spec",
+                    check_package_name=False)
         patches = ["first.patch", "second.patch", "third.patch"]
         rewritten = planex.patchqueue.expand_patchqueue(spec, patches)
         self.assertIn("Patch0: first.patch\n", rewritten)
         self.assertIn("Patch1: second.patch\n", rewritten)
         self.assertIn("Patch2: third.patch\n", rewritten)
+
+    def test_autosetup_check(self):
+        spec = Spec("tests/data/ocaml-uri.spec", check_package_name=False)
+        patches = ["first.patch"]
+        with self.assertRaises(planex.patchqueue.SpecMissingAutosetup):
+            planex.patchqueue.expand_patchqueue(spec, patches)

--- a/tests/test_patchqueue.py
+++ b/tests/test_patchqueue.py
@@ -49,7 +49,13 @@ class BasicTests(unittest.TestCase):
         self.assertIn("Patch1: second.patch\n", rewritten)
         self.assertIn("Patch2: third.patch\n", rewritten)
 
-    def test_autosetup_check(self):
+    def test_autosetup_present(self):
+        spec = Spec("tests/data/manifest/branding-xenserver.spec",
+                    check_package_name=False)
+        patches = ["first.patch"]
+        planex.patchqueue.expand_patchqueue(spec, patches)
+
+    def test_autosetup_missing(self):
         spec = Spec("tests/data/ocaml-uri.spec", check_package_name=False)
         patches = ["first.patch"]
         with self.assertRaises(planex.patchqueue.SpecMissingAutosetup):


### PR DESCRIPTION
When adding patch lines (e.g. Patch0 etc), planex assumes that they will be applied by rpm, but this is reliant on having a %autosetup with a -p1 argument in your %prep section.

This change verifies this assumption and raises an exception if it's not the case.