### PR TITLE
Pass through SSH_AUTH_SOCK, if defined

### DIFF
--- a/docker/entry
+++ b/docker/entry
@@ -28,10 +28,10 @@ subprocess.call(["useradd", "build",
 
 # Become the 'build' user.  If no command argument was provided,
 # start an interactive shell.
-su_cmd = ["su", "-", "build"]
+sudo_cmd = ["sudo", "-u", "build", "-i"]
 if len(sys.argv) > 1:
-    su_cmd += ["-c", " ".join(sys.argv[1:])]
+    sudo_cmd += [" ".join(sys.argv[1:])]
 
-print "Becoming build user: %s" % " ".join(su_cmd)
+print "Becoming build user: %s" % " ".join(sudo_cmd)
 sys.stdout.flush()
-os.execvp(su_cmd[0], su_cmd)
+os.execvp(sudo_cmd[0], sudo_cmd)

--- a/docker/entry
+++ b/docker/entry
@@ -29,6 +29,10 @@ subprocess.call(["useradd", "build",
 # Become the 'build' user.  If no command argument was provided,
 # start an interactive shell.
 sudo_cmd = ["sudo", "-u", "build", "-i"]
+
+if "SSH_AUTH_SOCK" in os.environ:
+    sudo_cmd += ["SSH_AUTH_SOCK=%s" % os.environ["SSH_AUTH_SOCK"]]
+
 if len(sys.argv) > 1:
     sudo_cmd += [" ".join(sys.argv[1:])]
 

--- a/docker/planex-container
+++ b/docker/planex-container
@@ -23,8 +23,14 @@ docker_cmd = ["docker", "run",
               "--rm", "-i", "-t",
               "-v", "%s/_obj/var/cache/mock:/var/cache/mock" % os.getcwd(),
               "-v", "%s/_obj/var/cache/yum:/var/cache/yum" % os.getcwd(),
-              "-v", "%s:/build" % os.getcwd(),
-              PLANEX_CONTAINER] # need to add args here
+              "-v", "%s:/build" % os.getcwd()]
+
+if "SSH_AUTH_SOCK" in os.environ:
+    docker_cmd += ["-e", "SSH_AUTH_SOCK"]
+    docker_cmd += ["-v", "%s:%s" % (os.environ["SSH_AUTH_SOCK"],
+                                    os.environ["SSH_AUTH_SOCK"])]
+
+docker_cmd += [PLANEX_CONTAINER]
 
 if len(sys.argv) > 1:
     docker_cmd += sys.argv[1:]


### PR DESCRIPTION
If SSH_AUTH_SOCK is defined in the shell which runs planex-container,
mount the file which it points to into the container and pass through
the variable.   Inside the container, the entry script will pass the
environment variable through to the final shell.   This makes it possible to
clone Git repositories over SSH from within the container.
