### PR TITLE
Makefile.rules: add a dependency on the mock config

### DIFF
--- a/planex/Makefile.rules
+++ b/planex/Makefile.rules
@@ -65,6 +65,8 @@ endif
 .PHONY: all rpms
 all: $(TOPDIR) $(RPMS)
 
+$(RPMS): $(MOCK_CONFIGDIR)/$(MOCK_ROOT).cfg
+
 $(TOPDIR)/RPMS/repodata/repomd.xml: $(RPMS)
 	$(AT)$(CREATEREPO) $(CREATEREPO_FLAGS) $(TOPDIR)/RPMS
 


### PR DESCRIPTION
Make the mock config file an explicit dependency of $(RPMS) so that
they are rebuilt if it changes. It also allows the main makefile to
define a rule to generate the mock config.