### PR TITLE
clone: Handle non-fatal errors more gracefully

### DIFF
--- a/planex/cmd/clone.py
+++ b/planex/cmd/clone.py
@@ -79,6 +79,31 @@ def clone(url, destination, commitish):
     return repo
 
 
+def apply_patchqueue(base_repo, pq_repo, pq_dir):
+    """
+    Apply a patchqueue to a base repository
+    """
+    # Symlink the patchqueue repository into .git/patches
+    link_path = relpath(pq_repo.working_dir, base_repo.git_dir)
+    symlink(link_path, join(base_repo.git_dir, "patches"))
+
+    # Symlink the patchqueue directory to match the base_repo
+    # branch name as guilt expects
+    patchqueue_path = join(base_repo.git_dir, "patches",
+                           base_repo.active_branch.name)
+    branch_path = dirname(base_repo.active_branch.name)
+    util.makedirs(dirname(patchqueue_path))
+    symlink(relpath(pq_dir, branch_path), patchqueue_path)
+
+    # Create empty guilt status for the branch
+    status = join(patchqueue_path, 'status')
+    open(status, 'w').close()
+
+    # Push patchqueue
+    subprocess.check_call(['guilt', 'push', '--all'],
+                          cwd=base_repo.working_dir)
+
+
 def main(argv=None):
     """
     Entry point
@@ -100,23 +125,4 @@ def main(argv=None):
             if pin.base is not None:
                 print "Cloning %s" % pin.base
                 base_repo = clone(pin.base, args.repos, pin.base_commitish)
-
-                # Symlink the patchqueue repository into .git/patches
-                link_path = relpath(pq_repo.working_dir, base_repo.git_dir)
-                symlink(link_path, join(base_repo.git_dir, "patches"))
-
-                # Symlink the patchqueue directory to match the base_repo
-                # branch name as guilt expects
-                patchqueue_path = join(base_repo.git_dir, "patches",
-                                       base_repo.active_branch.name)
-                branch_path = dirname(base_repo.active_branch.name)
-                util.makedirs(dirname(patchqueue_path))
-                symlink(relpath(pin.patchqueue, branch_path), patchqueue_path)
-
-                # Create empty guilt status for the branch
-                status = join(patchqueue_path, 'status')
-                open(status, 'w').close()
-
-                # Push patchqueue
-                subprocess.check_call(['guilt', 'push', '--all'],
-                                      cwd=base_repo.working_dir)
+                apply_patchqueue(base_repo, pq_repo, pin.patchqueue)

--- a/planex/cmd/clone.py
+++ b/planex/cmd/clone.py
@@ -118,11 +118,15 @@ def main(argv=None):
             clone_jenkins(pin.url, args.repos, pin.commitish, args.credentials)
 
         else:
-            print "Cloning %s" % pin.url
-            util.makedirs(args.repos)
-            pq_repo = clone(pin.url, args.repos, pin.commitish)
+            try:
+                print "Cloning %s" % pin.url
+                util.makedirs(args.repos)
+                pq_repo = clone(pin.url, args.repos, pin.commitish)
 
-            if pin.base is not None:
-                print "Cloning %s" % pin.base
-                base_repo = clone(pin.base, args.repos, pin.base_commitish)
-                apply_patchqueue(base_repo, pq_repo, pin.patchqueue)
+                if pin.base is not None:
+                    print "Cloning %s" % pin.base
+                    base_repo = clone(pin.base, args.repos, pin.base_commitish)
+                    apply_patchqueue(base_repo, pq_repo, pin.patchqueue)
+
+            except git.GitCommandError as gce:
+                print gce.stderr

--- a/planex/cmd/clone.py
+++ b/planex/cmd/clone.py
@@ -100,8 +100,14 @@ def apply_patchqueue(base_repo, pq_repo, pq_dir):
     open(status, 'w').close()
 
     # Push patchqueue
-    subprocess.check_call(['guilt', 'push', '--all'],
-                          cwd=base_repo.working_dir)
+    # `guilt push --all` fails with a non-zero error code if the patchqueue
+    # is empty; this cannot be distinguished from a patch failing to apply,
+    # so skip trying to push if the patchqueue is empty.
+    patches = subprocess.check_output(['guilt', 'unapplied'],
+                                      cwd=base_repo.working_dir)
+    if patches:
+        subprocess.check_call(['guilt', 'push', '--all'],
+                              cwd=base_repo.working_dir)
 
 
 def main(argv=None):


### PR DESCRIPTION
planex-clone currently exits if the destination directory for a repository already exists or the patchqueue is empty.   In the first case we should continue cloning other pins;  in the second case we should not fail when pushing an empty patchqueue.