### PR TITLE
makesrpm: Do not rewrite %autosetup rules in spec files

### DIFF
--- a/planex/cmd/makesrpm.py
+++ b/planex/cmd/makesrpm.py
@@ -17,7 +17,6 @@ from planex.util import add_common_parser_options
 from planex.spec import Spec
 from planex.link import Link
 from planex.patchqueue import Patchqueue
-from planex.tarball import extract_topdir
 from planex.tarball import Tarball
 
 
@@ -136,12 +135,9 @@ def populate_working_directory(tmpdir, spec, link, sources, patchqueue):
 
     manifests = {}
 
-    # Copy sources to working area, rewriting spec as needed
-    tarball_filters = ['.tar.gz', '.tar.bz2']
+    # Copy sources to working area
     for source in sources:
         extract_commit(source, manifests)
-        if any([ext in source for ext in tarball_filters]):
-            extract_topdir(tmp_specfile, source)
         shutil.copy(source, tmpdir)
 
     if manifests:

--- a/planex/tarball.py
+++ b/planex/tarball.py
@@ -2,7 +2,6 @@
 tarball: Utilities for tar archives
 """
 
-import fileinput
 import os
 import tarfile
 
@@ -69,25 +68,6 @@ def archive_root(tar):
         if top_element.isdir():
             return topname
     return ''
-
-
-def extract_topdir(tmp_specfile, source):
-    """
-    Set the topdir name taken from the source tarball
-    """
-    for line in fileinput.input(tmp_specfile, inplace=True):
-        if 'autosetup' in line:
-            tar = tarfile.open(source)
-            names = tar.getnames()
-            topname = os.path.commonprefix(names)
-            if topname in names:
-                top_element = tar.getmember(topname)
-                if top_element.isdir():
-                    print "%s -n %s" % (line.strip(), topname)
-            else:
-                print "%s -c" % line.strip()
-        else:
-            print line,
 
 
 def make(inputdir, outputfile, mode=None):


### PR DESCRIPTION
GitWeb synthetic tarballs do not unpack into a top level directory with
the name RPM expects.   To work around this, we rewrite %autosetup rules
in spec files.   GitHub generates tarballs which are acceptable to RPM
by default and BitBucket allows the top level directory name to be
specified in the tarball URL, so this rewrite is no longer required.

Signed-off-by: Euan Harris <euan.harris@citrix.com>