### PR TITLE
Makefile.rules: Fetch rule potentially applies to everything in _build/SOURCES

### DIFF
--- a/planex/Makefile.rules
+++ b/planex/Makefile.rules
@@ -116,8 +116,8 @@ MANIFESTS/%.json:
 ############################################################################
 
 # Fetch a source tarball listed in a spec file.
-.DELETE_ON_ERROR: %.tar %.tar.gz %.tar.xz %.tar.bz2 %.tgz %.tbz %.zip %.pdf %.cpio
-%.tar %.tar.gz %.tar.xz %.tar.bz2 %.tgz %.tbz %.zip %.pdf %.cpio:
+.DELETE_ON_ERROR: $(TOPDIR)/SOURCES/%
+$(TOPDIR)/SOURCES/%:
 	@echo [FETCH] $@
 	$(AT)$(FETCH) $(FETCH_FLAGS) $< $@
 


### PR DESCRIPTION
Previously we had an ugly list of suffixes matching files which could
be downloaded by planex-fetch.   It is neater to say that any target
in _build/SOURCES could potentially be downloaded.  This also allows
us to download non-archive sources which do not have a consistent set
of suffixes.

Signed-off-by: Euan Harris <euan.harris@citrix.com>