### PR TITLE
Remove preconfigured yum repos as last step of build 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,3 +34,5 @@ RUN python setup.py build \
 WORKDIR /build
 COPY docker/entry /entry
 ENTRYPOINT ["/entry"]
+
+RUN rm /etc/yum.repos.d/*


### PR DESCRIPTION
Avoid unexpected fallback by removing all yum repos and require the build process to add them

Signed-off-by: Mark Syms <mark.syms@citrix.com>