### PR TITLE
tests: Use assertItemsEqual() to compare lists

### DIFF
--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -38,28 +38,28 @@ class RpmTests(unittest.TestCase):
         self.assertEqual(self.spec.version(), "0.9.8")
 
     def test_provides(self):
-        self.assertEqual(
+        self.assertItemsEqual(
             self.spec.provides(),
-            set(["ocaml-cohttp", "ocaml-cohttp-devel"]))
+            ["ocaml-cohttp", "ocaml-cohttp-devel"])
 
     def test_source_urls(self):
-        self.assertEqual(
-            set(self.spec.source_urls()),
-            set(["https://github.com/mirage/ocaml-cohttp/archive/"
-                 "ocaml-cohttp-0.9.8/ocaml-cohttp-0.9.8.tar.gz",
-                 "ocaml-cohttp-init",
-                 "ocaml-cohttp-service",
-                 "cohttp0.patch",
-                 "cohttp1.patch"]))
+        self.assertItemsEqual(
+            self.spec.source_urls(),
+            ["https://github.com/mirage/ocaml-cohttp/archive/"
+             "ocaml-cohttp-0.9.8/ocaml-cohttp-0.9.8.tar.gz",
+             "ocaml-cohttp-init",
+             "ocaml-cohttp-service",
+             "cohttp0.patch",
+             "cohttp1.patch"])
 
     def test_source_paths(self):
-        self.assertEqual(
-            set(self.spec.source_paths()),
-            set(["./SOURCES/ocaml-cohttp/ocaml-cohttp-0.9.8.tar.gz",
-                 "./SOURCES/ocaml-cohttp/ocaml-cohttp-init",
-                 "./SOURCES/ocaml-cohttp/ocaml-cohttp-service",
-                 "./SOURCES/ocaml-cohttp/cohttp0.patch",
-                 "./SOURCES/ocaml-cohttp/cohttp1.patch"]))
+        self.assertItemsEqual(
+            self.spec.source_paths(),
+            ["./SOURCES/ocaml-cohttp/ocaml-cohttp-0.9.8.tar.gz",
+             "./SOURCES/ocaml-cohttp/ocaml-cohttp-init",
+             "./SOURCES/ocaml-cohttp/ocaml-cohttp-service",
+             "./SOURCES/ocaml-cohttp/cohttp0.patch",
+             "./SOURCES/ocaml-cohttp/cohttp1.patch"])
 
     def test_buildrequires(self):
         self.assertEqual(
@@ -78,27 +78,24 @@ class RpmTests(unittest.TestCase):
     def test_binary_package_paths(self):
         machine = get_rpm_machine()
 
-        self.assertEqual(
-            sorted(self.spec.binary_package_paths()),
-            [
-                path.format(machine=machine) for path in
-                sorted([
-                    "./RPMS/{machine}/ocaml-cohttp-0.9.8-1.el6.{machine}.rpm",
-                    "./RPMS/{machine}/" +
-                    "ocaml-cohttp-devel-0.9.8-1.el6.{machine}.rpm"])
-            ]
+        self.assertItemsEqual(
+            self.spec.binary_package_paths(),
+            [path.format(machine=machine) for path in
+             ["./RPMS/{machine}/ocaml-cohttp-0.9.8-1.el6.{machine}.rpm",
+              "./RPMS/{machine}/" +
+              "ocaml-cohttp-devel-0.9.8-1.el6.{machine}.rpm"]]
         )
 
     def test_local_sources(self):
-        self.assertEqual(
-            set(self.spec.local_sources()),
-            set(["ocaml-cohttp-init",
-                 "ocaml-cohttp-service"])
+        self.assertItemsEqual(
+            self.spec.local_sources(),
+            ["ocaml-cohttp-init",
+             "ocaml-cohttp-service"]
         )
 
     def test_local_patches(self):
-        self.assertEqual(
-            set(self.spec.local_patches()),
-            set(["cohttp0.patch",
-                 "cohttp1.patch"])
+        self.assertItemsEqual(
+            self.spec.local_patches(),
+            ["cohttp0.patch",
+             "cohttp1.patch"]
         )

--- a/tests/test_tarball.py
+++ b/tests/test_tarball.py
@@ -28,41 +28,41 @@ class BasicTests(unittest.TestCase):
         self.tarball.close()
 
     def test_archive_root(self):
-        assert self.tarball.archive_root == "patchqueue"
+        self.assertEqual(self.tarball.archive_root, "patchqueue")
 
     def test_getnames(self):
         expected = ["test.spec",
                     "SOURCES/test1.source",
                     "SOURCES/test2.source"]
         actual = self.tarball.getnames()
-        self.assertEqual(sorted(expected), sorted(actual))
+        self.assertItemsEqual(expected, actual)
 
     def test_getnames_prefix(self):
         self.tarball.prefix = "SOURCES"
         expected = ["test1.source",
                     "test2.source"]
         actual = self.tarball.getnames()
-        self.assertEqual(sorted(expected), sorted(actual))
+        self.assertItemsEqual(expected, actual)
 
     def test_extractfile(self):
         file = self.tarball.extractfile("SOURCES/test1.source")
         expected = ["test1.source contents\n"]
         actual = file.readlines()
-        self.assertEqual(sorted(expected), sorted(actual))
+        self.assertItemsEqual(expected, actual)
 
     def test_extractfile_prefix(self):
         self.tarball.prefix = "SOURCES"
         file = self.tarball.extractfile("test1.source")
         expected = ["test1.source contents\n"]
         actual = file.readlines()
-        self.assertEqual(sorted(expected), sorted(actual))
+        self.assertItemsEqual(expected, actual)
 
     def test_extract(self):
         self.tarball.extract("SOURCES/test1.source", self.tmpdir)
         with open(os.path.join(self.tmpdir, "test1.source")) as output:
             expected = ["test1.source contents\n"]
             actual = output.readlines()
-        self.assertEqual(sorted(expected), sorted(actual))
+        self.assertItemsEqual(expected, actual)
 
     def test_extract_prefix(self):
         self.tarball.prefix = "SOURCES"
@@ -70,4 +70,4 @@ class BasicTests(unittest.TestCase):
         with open(os.path.join(self.tmpdir, "test1.source")) as output:
             expected = ["test1.source contents\n"]
             actual = output.readlines()
-        self.assertEqual(sorted(expected), sorted(actual))
+        self.assertItemsEqual(expected, actual)


### PR DESCRIPTION
This function asserts that two lists contain the same elements, ignoring
element order.

Signed-off-by: Euan Harris <euan.harris@citrix.com>