### PR TITLE
Patchqueue property tests

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,4 +1,5 @@
 coverage
+hypothesis
 mock
 nose
 pep8

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+"""
+Tests for Planex
+"""

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,3 +1,7 @@
 """
 Tests for Planex
 """
+
+# Run these tests with 'nosetests':
+#   install the 'python-nose' package (Fedora/CentOS or Ubuntu)
+#   run 'nosetests' in the root of the repository

--- a/tests/strategies.py
+++ b/tests/strategies.py
@@ -1,0 +1,128 @@
+"""
+Hypothesis strategies, used to generate data for property-based
+testing of Planex modules.
+"""
+
+from collections import namedtuple
+import os
+import random
+import string
+
+from hypothesis import strategies as st
+
+
+class File(object):
+    """
+    Represents a standard file with a name and some content.
+    If no content is provided, random data is used.
+    """
+
+    def __init__(self, name, content=None):
+        self.name = name
+        self._content = content
+
+    def __repr__(self):
+        return "File(%r, %r)" % (self.name, self.content)
+
+    @property
+    def content(self):
+        """
+        Return the file's content.   If no content was provided when
+        the object was created, random content will be generated lazily.
+        """
+        # rpmbuild complains if source files are less than 13 bytes.
+        # Generating these bytes with hypothesis is expensive, and
+        # this effort is wasted if they are not used, so we will
+        # generate them lazily.   We use a random string so it is
+        # easy to verify that a file was properly copied into an
+        # RPM.
+        if self._content is None:
+            self._content = "".join(random.sample(string.printable, 20))
+        return self._content
+
+    def write(self, directory):
+        """
+        Write content to a file in directory.
+        """
+        path = open(os.path.join(directory, self.name))
+        with open(path, "w") as out:
+            out.writelines(self.content)
+        return path
+
+
+class Patch(namedtuple("Patch", "patch guards")):
+    """Represents a patch with optional guards"""
+    def __str__(self):
+        entry = self.patch.name
+        if self.guards:
+            entry += " #%s" % ",".join([str(g) for g in self.guards])
+        return entry
+
+    def has_negative_guards(self):
+        """Return true if the patch has any negative guards"""
+        return any([g.sign == '-' for g in self.guards])
+
+    def has_positive_guards(self):
+        """Return true if the patch has any positive guards"""
+        return any([g.sign == '+' for g in self.guards])
+
+    def write(self, directory):
+        """Write contents of the patch out to a file in the given
+        directory"""
+        return self.patch.write(directory)
+
+
+class Guard(namedtuple("Guard", "sign label")):
+    """Represents a patch guard"""
+    def __str__(self):
+        return self.sign + self.label
+
+
+class PatchQueue(namedtuple("PatchQueue", "patches")):
+    """Represents a patchqueue"""
+    def __str__(self):
+        return self.series()
+
+    def series(self):
+        """Return the PatchQueue's series file."""
+        return "\n".join([str(p) for p in self.patches])
+
+
+def files():
+    """Returns a strategy which generates a File object with random
+    contents.
+    """
+    return st.builds(File, st.text(alphabet="abcdefghijklmnopqrstuvwxyz",
+                                   min_size=1, max_size=5))
+
+
+def guard_names():
+    """Returns a strategy which generates a patchqueue guard name.
+    """
+    return st.sampled_from(["alpha", "bravo", "charlie", "delta"])
+
+
+def guards():
+    """Returns a strategy which generates a patchqueue guard.
+    """
+    return st.builds(Guard, st.sampled_from(["+", "-"]), guard_names())
+
+
+def patches():
+    """Returns a strategy which generates a Patch object.
+    At present, planex.patchqueue.Patchqueue only supports a single
+    guard on each patch.
+    """
+    # If support for multiple guards is added, the max_size constraint
+    # can be increased.
+    return st.builds(Patch, files(), st.sets(guards(), min_size=0, max_size=1))
+
+
+def patchqueues():
+    """Returns a strategy which generates a PatchQueue object containing
+    a list of uniquely-named Patch objects.
+    """
+    return st.builds(PatchQueue,
+                     st.lists(patches(),
+                              unique_by=lambda x: x.patch.name,
+                              max_size=5))

--- a/tests/test_patchqueue.py
+++ b/tests/test_patchqueue.py
@@ -1,22 +1,20 @@
 """Test patchqueue handling"""
 
-# Run these tests with 'nosetests':
-#   install the 'python-nose' package (Fedora/CentOS or Ubuntu)
-#   run 'nosetests' in the root of the repository
-
-import glob
-import os
-import os.path
 import shutil
-import sys
 import tempfile
 import unittest
+
+from hypothesis import given
+from nose.plugins.attrib import attr
+
+import tests.strategies as tst
 
 import planex.patchqueue
 from planex.spec import Spec
 
 
 class BasicTests(unittest.TestCase):
+    """Basic tests of patchqueue handling"""
     # unittest.TestCase has more methods than Pylint permits
     # pylint: disable=R0904
 
@@ -29,11 +27,11 @@ class BasicTests(unittest.TestCase):
         shutil.rmtree(self.test_dir)
 
     def test_patch_guards(self):
+        """Patch guards are applied correctly"""
         series = ("patch_no_guard_or_comment\n",
                   "patch_with_a_comment # this is a comment\n",
                   "patch_with_a_positive_guard #+aguard\n",
-                  "patch_with_a_negative_guard #-aguard\n",
-                  )
+                  "patch_with_a_negative_guard #-aguard\n")
 
         applied = list(planex.patchqueue.parse_patchseries(series))
 
@@ -43,6 +41,7 @@ class BasicTests(unittest.TestCase):
         self.assertIn("patch_with_a_negative_guard", applied)
 
     def test_rewrite_spec(self):
+        """Patches are inserted into rewritten spec file"""
         spec = Spec("tests/data/manifest/branding-xenserver.spec",
                     check_package_name=False)
         patches = ["first.patch", "second.patch", "third.patch"]
@@ -52,22 +51,20 @@ class BasicTests(unittest.TestCase):
         self.assertIn("Patch2: third.patch\n", rewritten)
 
     def test_autosetup_present(self):
+        """Patchqueue application succeeds if %autosetup is present"""
         spec = Spec("tests/data/manifest/branding-xenserver.spec",
                     check_package_name=False)
         patches = ["first.patch"]
-        planex.patchqueue.expand_patchqueue(spec, patches)
+        rewritten = planex.patchqueue.expand_patchqueue(spec, patches)
+        self.assertIn("Patch0: first.patch\n", rewritten)
 
     def test_autosetup_missing(self):
+        """Patchqueue application fails if %autosetup is not present"""
         spec = Spec("tests/data/ocaml-uri.spec", check_package_name=False)
         patches = ["first.patch"]
         with self.assertRaises(planex.patchqueue.SpecMissingAutosetup):
             planex.patchqueue.expand_patchqueue(spec, patches)
 
-
-from hypothesis import given
-from nose.plugins.attrib import attr
-
-import tests.strategies as tst
 
 # Mercurial's guard logic is documented in:
 #

--- a/tests/test_patchqueue.py
+++ b/tests/test_patchqueue.py
@@ -1,3 +1,5 @@
+"""Test patchqueue handling"""
+
 # Run these tests with 'nosetests':
 #   install the 'python-nose' package (Fedora/CentOS or Ubuntu)
 #   run 'nosetests' in the root of the repository
@@ -60,3 +62,95 @@ class BasicTests(unittest.TestCase):
         patches = ["first.patch"]
         with self.assertRaises(planex.patchqueue.SpecMissingAutosetup):
             planex.patchqueue.expand_patchqueue(spec, patches)
+
+
+from hypothesis import given
+from nose.plugins.attrib import attr
+
+import tests.strategies as tst
+
+# Mercurial's guard logic is documented in:
+#
+#   O'Sullivan, B. "Mercurial: The Definitive Guide", Chapter 13 "Advanced
+#   uses of Mercurial queues", in the section titled "MQ's rules for
+#   applying patches"
+#
+#   http://hgbook.red-bean.com/read/advanced-uses-of-mercurial-queues.html
+
+
+# The PatchQueue class currently only handles a single guard on each
+# patch.   If support for multiple guards is added, the tests should
+# check behaviour when a patch has positive and negative guards with
+# the same label.   'hg qguard' won't create such a guard, but it can
+# be added to the series file by hand and without extra constraints
+# hypothesis will generate one.  Testing with hg shows that the positive
+# guard overrides the negative one in this case: 'patch #+foo,-foo' is
+# equivalent to 'patch #+foo".
+
+
+class PatchqueueGuardTests(unittest.TestCase):
+    """Test patchqueue series processing with guards"""
+
+    @attr("pq")
+    @given(tst.patchqueues(), tst.guard_names())
+    def test_application_order(self, patchqueue, guard):
+        """Patches are applied in patchqueue order"""
+        series = patchqueue.series().splitlines(True)
+        applied = list(planex.patchqueue.parse_patchseries(series, guard))
+        # Filter unapplied patches out of the patchqueue, yielding a list
+        # of applied patches in patchqueue order
+        expected_inorder = [p.patch.name for p in patchqueue.patches
+                            if p.patch.name in applied]
+        self.assertEqual(applied, expected_inorder)
+
+    @attr("pq")
+    @given(tst.patchqueues(), tst.guard_names())
+    def test_unguarded(self, patchqueue, guard):
+        """Unguarded patches are always applied"""
+        series = patchqueue.series().splitlines(True)
+        applied = list(planex.patchqueue.parse_patchseries(series, guard))
+        expected = [p.patch.name for p in patchqueue.patches if not p.guards]
+        self.assertTrue(all([p in applied for p in expected]))
+
+    @attr("pq")
+    @given(tst.patchqueues(), tst.guard_names())
+    def test_neg_guarded_apply(self, patchqueue, guard):
+        """Negatively-guarded patches are applied if guard is not selected"""
+        series = patchqueue.series().splitlines(True)
+        applied = list(planex.patchqueue.parse_patchseries(series, guard))
+        expected = [p.patch.name for p in patchqueue.patches
+                    if p.has_negative_guards() and
+                    tst.Guard('-', guard) not in p.guards]
+        self.assertTrue(all([p in applied for p in expected]))
+
+    @attr("pq")
+    @given(tst.patchqueues(), tst.guard_names())
+    def test_neg_guarded_skip(self, patchqueue, guard):
+        """Negatively-guarded patches are skipped if guard is selected"""
+        series = patchqueue.series().splitlines(True)
+        applied = list(planex.patchqueue.parse_patchseries(series, guard))
+        not_expected = [p.patch.name for p in patchqueue.patches
+                        if tst.Guard('-', guard) in p.guards and
+                        tst.Guard('+', guard) not in p.guards]
+        self.assertTrue(all([p not in applied for p in not_expected]))
+
+    @attr("pq")
+    @given(tst.patchqueues(), tst.guard_names())
+    def test_pos_guarded_apply(self, patchqueue, guard):
+        """Positively guarded patches are applied if guard is selected"""
+        series = patchqueue.series().splitlines(True)
+        applied = list(planex.patchqueue.parse_patchseries(series, guard))
+        expected = [p.patch.name for p in patchqueue.patches
+                    if tst.Guard("+", guard) in p.guards]
+        self.assertTrue(all([p in applied for p in expected]))
+
+    @attr("pq")
+    @given(tst.patchqueues(), tst.guard_names())
+    def test_pos_guarded_skip(self, patchqueue, guard):
+        """Positively-guarded patches are skipped if guard is not selected"""
+        series = patchqueue.series().splitlines(True)
+        applied = list(planex.patchqueue.parse_patchseries(series, guard))
+        not_expected = [p.patch.name for p in patchqueue.patches
+                        if p.has_positive_guards() and
+                        tst.Guard('+', guard) not in p.guards]
+        self.assertTrue(all([p not in applied for p in not_expected]))


### PR DESCRIPTION
This pull request adds some Hypothesis property-based tests for patchqueue guard handling.  Guard handling was already tested by point test in test_patchqueues.py so coverage reported by nosetests does not change, but the property-based tests explore some corner cases which the point test does not.