### PR TITLE
Consolidate argparse

### DIFF
--- a/planex/cmd/args.py
+++ b/planex/cmd/args.py
@@ -1,0 +1,20 @@
+"""
+Common argparse utilities for planex command line tools
+"""
+
+import pkg_resources
+
+
+def add_common_parser_options(parser):
+    """
+    Takes a parser and adds the following command line flags:
+        * --quiet/--warn
+        * -v/--verbose/--debug
+        * --version
+    """
+    parser.add_argument('--quiet', '--warn', action='store_true',
+                        help='Only log warnings and errors')
+    parser.add_argument('-v', '--verbose', '--debug', action='store_true',
+                        help='Enable debug logging')
+    parser.add_argument('--version', action='version', version="%%(prog)s %s" %
+                        pkg_resources.require("planex")[0].version)

--- a/planex/cmd/args.py
+++ b/planex/cmd/args.py
@@ -2,6 +2,7 @@
 Common argparse utilities for planex command line tools
 """
 
+import argparse
 import pkg_resources
 
 
@@ -18,3 +19,21 @@ def add_common_parser_options(parser):
                         help='Enable debug logging')
     parser.add_argument('--version', action='version', version="%%(prog)s %s" %
                         pkg_resources.require("planex")[0].version)
+
+
+def rpm_macro(string):
+    """
+    Argparse type handler for RPM macro command line arguments of the form:
+
+       --define "foo bar"
+
+    Returns a (foo, bar) tuple if successful, otherwise raises
+    ArgumentTypeError.
+    """
+    macro = tuple(string.split(' ', 1))
+
+    if len(macro) != 2:
+        msg = "malformed macro passed to --define: %r" % string
+        raise argparse.ArgumentTypeError(msg)
+
+    return macro

--- a/planex/cmd/createmockconfig.py
+++ b/planex/cmd/createmockconfig.py
@@ -13,7 +13,7 @@ import StringIO
 import yum
 import argcomplete
 
-from planex.util import add_common_parser_options
+from planex.cmd.args import add_common_parser_options
 from planex.util import setup_logging
 from planex.util import setup_sigint_handler
 

--- a/planex/cmd/depend.py
+++ b/planex/cmd/depend.py
@@ -9,7 +9,7 @@ import sys
 import urlparse
 
 import argcomplete
-from planex.cmd.args import add_common_parser_options
+from planex.cmd.args import add_common_parser_options, rpm_macro
 from planex.util import setup_sigint_handler
 from planex.cmd import manifest
 import planex.spec as pkg
@@ -119,7 +119,7 @@ def parse_args_or_exit(argv=None):
         action="store_false", default=True,
         help="Don't check that package name matches spec file name")
     parser.add_argument(
-        "-D", "--define", default=[], action="append",
+        "-D", "--define", default=[], action="append", type=rpm_macro,
         help="--define='MACRO EXPR' define MACRO with value EXPR")
     parser.add_argument(
         "-P", "--pins-dir", default="PINS",
@@ -152,13 +152,6 @@ def main(argv=None):
     print "# -*- makefile -*-"
     print "# vim:ft=make:"
 
-    macros = [tuple(macro.split(' ', 1)) for macro in args.define]
-
-    if any(len(macro) != 2 for macro in macros):
-        _err = [macro for macro in macros if len(macro) != 2]
-        print "error: malformed macro passed to --define: %r" % _err
-        sys.exit(1)
-
     pins = []
     if args.pins_dir:
         pins_glob = os.path.join(args.pins_dir, "*.pin")
@@ -170,7 +163,7 @@ def main(argv=None):
         try:
             spec = pkg.Spec(spec_path,
                             check_package_name=args.check_package_names,
-                            defines=macros)
+                            defines=args.define)
             spec_name = os.path.basename(spec_path)
             specs[spec_name] = spec
 

--- a/planex/cmd/depend.py
+++ b/planex/cmd/depend.py
@@ -9,7 +9,7 @@ import sys
 import urlparse
 
 import argcomplete
-from planex.util import add_common_parser_options
+from planex.cmd.args import add_common_parser_options
 from planex.util import setup_sigint_handler
 from planex.cmd import manifest
 import planex.spec as pkg

--- a/planex/cmd/extract.py
+++ b/planex/cmd/extract.py
@@ -12,7 +12,7 @@ import tarfile
 import argcomplete
 
 from planex.link import Link
-from planex.util import add_common_parser_options
+from planex.cmd.args import add_common_parser_options
 from planex.util import setup_logging
 from planex.util import setup_sigint_handler
 

--- a/planex/cmd/fetch.py
+++ b/planex/cmd/fetch.py
@@ -14,7 +14,7 @@ import pkg_resources
 import pycurl
 
 from planex.link import Link
-from planex.util import add_common_parser_options
+from planex.cmd.args import add_common_parser_options
 from planex.util import run
 from planex.util import setup_logging
 from planex.util import setup_sigint_handler

--- a/planex/cmd/fetch.py
+++ b/planex/cmd/fetch.py
@@ -14,7 +14,7 @@ import pkg_resources
 import pycurl
 
 from planex.link import Link
-from planex.cmd.args import add_common_parser_options
+from planex.cmd.args import add_common_parser_options, rpm_macro
 from planex.util import run
 from planex.util import setup_logging
 from planex.util import setup_sigint_handler
@@ -168,7 +168,8 @@ def parse_args_or_exit(argv=None):
                         "file name")
     parser.add_argument('--mirror',
                         help="Set the URL to a local mirror for downloads")
-    parser.add_argument("-D", "--define", default=[], action="append",
+    parser.add_argument("-D", "--define", default=[],
+                        action="append", type=rpm_macro,
                         help="--define='MACRO EXPR' define MACRO with "
                         "value EXPR")
     argcomplete.autocomplete(parser)
@@ -181,16 +182,9 @@ def fetch_sources(args):
     appropriate.
     """
 
-    macros = [tuple(macro.split(' ', 1)) for macro in args.define]
-
-    if any(len(macro) != 2 for macro in macros):
-        _err = [macro for macro in macros if len(macro) != 2]
-        print "error: malformed macro passed to --define: %r" % _err
-        sys.exit(1)
-
     spec = planex.spec.Spec(args.spec_or_link,
                             check_package_name=args.check_package_names,
-                            defines=macros)
+                            defines=args.define)
 
     try:
         sources = [url_for_source(spec, source) for source in args.sources]

--- a/planex/cmd/init.py
+++ b/planex/cmd/init.py
@@ -10,7 +10,7 @@ import sys
 import argcomplete
 from pkg_resources import resource_filename
 
-from planex.util import add_common_parser_options
+from planex.cmd.args import add_common_parser_options
 from planex.util import setup_sigint_handler
 
 

--- a/planex/cmd/makesrpm.py
+++ b/planex/cmd/makesrpm.py
@@ -13,7 +13,7 @@ import tempfile
 
 import argparse
 import argcomplete
-from planex.util import add_common_parser_options
+from planex.cmd.args import add_common_parser_options
 from planex.spec import Spec
 from planex.link import Link
 from planex.patchqueue import Patchqueue

--- a/planex/cmd/manifest.py
+++ b/planex/cmd/manifest.py
@@ -10,7 +10,7 @@ import os
 
 import argcomplete
 
-from planex.util import add_common_parser_options
+from planex.cmd.args import add_common_parser_options
 from planex.util import setup_logging
 from planex.link import Link
 from planex.spec import Spec

--- a/planex/cmd/mock.py
+++ b/planex/cmd/mock.py
@@ -12,7 +12,7 @@ from uuid import uuid4
 
 import argparse
 import argcomplete
-from planex.util import add_common_parser_options
+from planex.cmd.args import add_common_parser_options
 
 
 def parse_args_or_exit(argv=None):

--- a/planex/cmd/patchqueue.py
+++ b/planex/cmd/patchqueue.py
@@ -18,6 +18,7 @@ from planex.spec import Spec
 import planex.git as git
 import planex.tarball as tarball
 import planex.util as util
+from planex.cmd.args import add_common_parser_options
 
 
 def parse_args_or_exit(argv=None):
@@ -26,7 +27,7 @@ def parse_args_or_exit(argv=None):
     """
     parser = argparse.ArgumentParser(
         description='Create a patchqueue from a linked Git repository')
-    util.add_common_parser_options(parser)
+    add_common_parser_options(parser)
     parser.add_argument("link", metavar="LINK", help="link file")
     parser.add_argument("tarball", metavar="TARBALL", help="tarball")
     parser.add_argument("--repos", default="repos",

--- a/planex/util.py
+++ b/planex/util.py
@@ -12,8 +12,6 @@ import signal
 import subprocess
 import sys
 
-import pkg_resources
-
 import __main__
 
 
@@ -81,21 +79,6 @@ def setup_logging(args):
 
     logging.basicConfig(format=fmt, datefmt=datefmt, level=loglevel)
     logging.debug("Initialised logging.")
-
-
-def add_common_parser_options(parser):
-    """
-    Takes a parser and adds the following command line flags:
-        * --quiet/--warn
-        * -v/--verbose/--debug
-        * --version
-    """
-    parser.add_argument('--quiet', '--warn', action='store_true',
-                        help='Only log warnings and errors')
-    parser.add_argument('-v', '--verbose', '--debug', action='store_true',
-                        help='Enable debug logging')
-    parser.add_argument('--version', action='version', version="%%(prog)s %s" %
-                        pkg_resources.require("planex")[0].version)
 
 
 def hash_of_file(path):


### PR DESCRIPTION
Move planex.utils.add_common_parser_options into planex.cmd.args
Add an argparse 'type' to handle RPM macro definitions passed using the --define option