### PR TITLE
depend: Stop disabling pylint's 'too-many-statements' warning

### DIFF
--- a/planex/cmd/depend.py
+++ b/planex/cmd/depend.py
@@ -143,7 +143,7 @@ def main(argv=None):
     """
     Entry point
     """
-    # pylint: disable=R0914, R0915
+    # pylint: disable=R0914
 
     setup_sigint_handler()
     args = parse_args_or_exit(argv)


### PR DESCRIPTION
Signed-off-by: Euan Harris <euan.harris@citrix.com>