### PR TITLE
depend: Consolidate all manifest-related dependencies in one function

### DIFF
--- a/tests/test_depend.py
+++ b/tests/test_depend.py
@@ -30,8 +30,6 @@ class BasicTests(unittest.TestCase):
             "_build/SRPMS/ocaml-cohttp-0.9.8-1.el6.src.rpm: "
             "tests/data/ocaml-cohttp.spec\n"
             "_build/SRPMS/ocaml-cohttp-0.9.8-1.el6.src.rpm: "
-            "./MANIFESTS/ocaml-cohttp.json\n"
-            "_build/SRPMS/ocaml-cohttp-0.9.8-1.el6.src.rpm: "
             "_build/SOURCES/ocaml-cohttp/ocaml-cohttp-0.9.8.tar.gz\n"
             "_build/SRPMS/ocaml-cohttp-0.9.8-1.el6.src.rpm: "
             "SOURCES/ocaml-cohttp/ocaml-cohttp-init\n"


### PR DESCRIPTION
We need to take care when reordering dependencies, as dependencies
appear in variables such as $<, $? and $^ in the order in which they
are declared in the makefile.   Changing the ordering of dependencies
can therefore break tools which use positional parameters.

Signed-off-by: Euan Harris <euan.harris@citrix.com>