### PR TITLE
depend: Remove unused --repos_path argument

### DIFF
--- a/planex/cmd/depend.py
+++ b/planex/cmd/depend.py
@@ -113,9 +113,6 @@ def parse_args_or_exit(argv=None):
     add_common_parser_options(parser)
     parser.add_argument("specs", metavar="SPEC", nargs="+", help="spec file")
     parser.add_argument(
-        "-r", "--repos_path", metavar="DIR", default="repos",
-        help='Local path to the repositories')
-    parser.add_argument(
         "--no-package-name-check", dest="check_package_names",
         action="store_false", default=True,
         help="Don't check that package name matches spec file name")


### PR DESCRIPTION
This argument has not been connected to anything since
5fa3d866f15787d4bef37a4ef37e35e75da0b306

Signed-off-by: Euan Harris <euan.harris@citrix.com>