### PR TITLE
args: Define common argument parsers from which others can inherit

### DIFF
--- a/planex/cmd/args.py
+++ b/planex/cmd/args.py
@@ -46,6 +46,21 @@ def rpm_define_parser():
     return parser
 
 
+def keeptmp_parser():
+    """
+    Returns a parser which handles the "--keeptmp" option.
+
+    This parser can then be used as a 'parent' to other parsers
+    which will inherit these options.
+
+    See https://docs.python.org/2.7/library/argparse.html#parents
+    """
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--keeptmp", action="store_true",
+                        help="Keep temporary files")
+    return parser
+
+
 def rpm_macro(string):
     """
     Argparse type handler for RPM macro command line arguments of the form:

--- a/planex/cmd/args.py
+++ b/planex/cmd/args.py
@@ -6,19 +6,26 @@ import argparse
 import pkg_resources
 
 
-def add_common_parser_options(parser):
+def common_base_parser():
     """
-    Takes a parser and adds the following command line flags:
+    Returns a parser which handles the following common flags:
         * --quiet/--warn
         * -v/--verbose/--debug
         * --version
+
+    This parser can then be used as a 'parent' to other parsers
+    which will inherit these options.
+
+    See https://docs.python.org/2.7/library/argparse.html#parents
     """
+    parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument('--quiet', '--warn', action='store_true',
                         help='Only log warnings and errors')
     parser.add_argument('-v', '--verbose', '--debug', action='store_true',
                         help='Enable debug logging')
     parser.add_argument('--version', action='version', version="%%(prog)s %s" %
                         pkg_resources.require("planex")[0].version)
+    return parser
 
 
 def rpm_macro(string):

--- a/planex/cmd/args.py
+++ b/planex/cmd/args.py
@@ -28,6 +28,24 @@ def common_base_parser():
     return parser
 
 
+def rpm_define_parser():
+    """
+    Returns a parser which handles rpmbuild-style "--define 'name macro'"
+    options.
+
+    This parser can then be used as a 'parent' to other parsers
+    which will inherit these options.
+
+    See https://docs.python.org/2.7/library/argparse.html#parents
+    """
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("-D", "--define", default=[], action="append",
+                        type=rpm_macro,
+                        help="--define='MACRO EXPR' "
+                             "define MACRO with value EXPR")
+    return parser
+
+
 def rpm_macro(string):
     """
     Argparse type handler for RPM macro command line arguments of the form:

--- a/planex/cmd/createmockconfig.py
+++ b/planex/cmd/createmockconfig.py
@@ -14,7 +14,7 @@ import StringIO
 import yum
 import argcomplete
 
-from planex.cmd.args import add_common_parser_options
+from planex.cmd.args import common_base_parser
 from planex.util import setup_logging
 from planex.util import setup_sigint_handler
 
@@ -110,8 +110,8 @@ def parse_args_or_exit(argv=None):
     """
     Parse command line options
     """
-    parser = argparse.ArgumentParser(description='Create mock config')
-    add_common_parser_options(parser)
+    parser = argparse.ArgumentParser(description='Create mock config',
+                                     parents=[common_base_parser()])
     parser.add_argument("mockconfig", metavar="OUTCFG",
                         help="output file")
     parser.add_argument("--configdir", metavar="CONFIGDIR", required=True,

--- a/planex/cmd/depend.py
+++ b/planex/cmd/depend.py
@@ -10,7 +10,7 @@ import sys
 import urlparse
 
 import argcomplete
-from planex.cmd.args import add_common_parser_options, rpm_macro
+from planex.cmd.args import common_base_parser, rpm_macro
 from planex.util import setup_sigint_handler, dedupe
 from planex.cmd import manifest
 from planex.spec import Spec, SpecNameMismatch
@@ -114,8 +114,8 @@ def parse_args_or_exit(argv=None):
     Parse command line options
     """
     parser = argparse.ArgumentParser(
-        description="Generate Makefile dependencies from RPM Spec files")
-    add_common_parser_options(parser)
+        description="Generate Makefile dependencies from RPM Spec files",
+        parents=[common_base_parser()])
     parser.add_argument("specs", metavar="SPEC", nargs="+", help="spec file")
     parser.add_argument(
         "--no-package-name-check", dest="check_package_names",

--- a/planex/cmd/depend.py
+++ b/planex/cmd/depend.py
@@ -10,7 +10,7 @@ import sys
 import urlparse
 
 import argcomplete
-from planex.cmd.args import common_base_parser, rpm_macro
+from planex.cmd.args import common_base_parser, rpm_define_parser
 from planex.util import setup_sigint_handler, dedupe
 from planex.cmd import manifest
 from planex.spec import Spec, SpecNameMismatch
@@ -115,15 +115,12 @@ def parse_args_or_exit(argv=None):
     """
     parser = argparse.ArgumentParser(
         description="Generate Makefile dependencies from RPM Spec files",
-        parents=[common_base_parser()])
+        parents=[common_base_parser(), rpm_define_parser()])
     parser.add_argument("specs", metavar="SPEC", nargs="+", help="spec file")
     parser.add_argument(
         "--no-package-name-check", dest="check_package_names",
         action="store_false", default=True,
         help="Don't check that package name matches spec file name")
-    parser.add_argument(
-        "-D", "--define", default=[], action="append", type=rpm_macro,
-        help="--define='MACRO EXPR' define MACRO with value EXPR")
     parser.add_argument(
         "--no-buildrequires", dest="buildrequires",
         action="store_false", default=True,

--- a/planex/cmd/fetch.py
+++ b/planex/cmd/fetch.py
@@ -14,7 +14,7 @@ import pkg_resources
 import pycurl
 
 from planex.link import Link
-from planex.cmd.args import common_base_parser, rpm_macro
+from planex.cmd.args import common_base_parser, rpm_define_parser
 from planex.util import run
 from planex.util import setup_logging
 from planex.util import setup_sigint_handler
@@ -155,7 +155,8 @@ def parse_args_or_exit(argv=None):
     Parse command line options
     """
     parser = argparse.ArgumentParser(description='Download package sources',
-                                     parents=[common_base_parser()])
+                                     parents=[common_base_parser(),
+                                              rpm_define_parser()])
     parser.add_argument('spec_or_link', help='RPM Spec or link file')
     parser.add_argument("sources", metavar="SOURCE", nargs="+",
                         help="Source file to fetch")
@@ -168,10 +169,6 @@ def parse_args_or_exit(argv=None):
                         "file name")
     parser.add_argument('--mirror',
                         help="Set the URL to a local mirror for downloads")
-    parser.add_argument("-D", "--define", default=[],
-                        action="append", type=rpm_macro,
-                        help="--define='MACRO EXPR' define MACRO with "
-                        "value EXPR")
     argcomplete.autocomplete(parser)
     return parser.parse_args(argv)
 

--- a/planex/cmd/fetch.py
+++ b/planex/cmd/fetch.py
@@ -14,7 +14,7 @@ import pkg_resources
 import pycurl
 
 from planex.link import Link
-from planex.cmd.args import add_common_parser_options, rpm_macro
+from planex.cmd.args import common_base_parser, rpm_macro
 from planex.util import run
 from planex.util import setup_logging
 from planex.util import setup_sigint_handler
@@ -154,8 +154,8 @@ def parse_args_or_exit(argv=None):
     """
     Parse command line options
     """
-    parser = argparse.ArgumentParser(description='Download package sources')
-    add_common_parser_options(parser)
+    parser = argparse.ArgumentParser(description='Download package sources',
+                                     parents=[common_base_parser()])
     parser.add_argument('spec_or_link', help='RPM Spec or link file')
     parser.add_argument("sources", metavar="SOURCE", nargs="+",
                         help="Source file to fetch")

--- a/planex/cmd/init.py
+++ b/planex/cmd/init.py
@@ -11,7 +11,7 @@ import sys
 import argcomplete
 from pkg_resources import resource_filename
 
-from planex.cmd.args import add_common_parser_options
+from planex.cmd.args import common_base_parser
 from planex.util import setup_sigint_handler
 
 
@@ -68,8 +68,8 @@ def parse_args_or_exit(argv=None):
     """
     Parse command line options
     """
-    parser = argparse.ArgumentParser(description='Download package sources')
-    add_common_parser_options(parser)
+    parser = argparse.ArgumentParser(description='Download package sources',
+                                     parents=[common_base_parser()])
     parser.add_argument('--rules', dest="rules",
                         action="store_true", default=False,
                         help="Print the full path to Makefile.rules")

--- a/planex/cmd/makesrpm.py
+++ b/planex/cmd/makesrpm.py
@@ -14,7 +14,7 @@ import tempfile
 
 import argparse
 import argcomplete
-from planex.cmd.args import common_base_parser
+from planex.cmd.args import common_base_parser, rpm_define_parser
 from planex.spec import Spec
 from planex.link import Link
 from planex.patchqueue import Patchqueue
@@ -27,13 +27,10 @@ def parse_args_or_exit(argv=None):
     """
     parser = argparse.ArgumentParser(
         description='Pack sources and patchqueues into a source RPM',
-        parents=[common_base_parser()])
+        parents=[common_base_parser(), rpm_define_parser()])
     parser.add_argument("spec", metavar="SPEC", help="Spec file")
     parser.add_argument("sources", metavar="SOURCE/PATCHQUEUE", nargs='*',
                         help="Source and patchqueue files")
-    parser.add_argument(
-        "-D", "--define", default=[], action="append",
-        help="--define='MACRO EXPR' define MACRO with value EXPR")
     parser.add_argument(
         "--keeptmp", action="store_true",
         help="keep temporary files")
@@ -63,7 +60,7 @@ def rpmbuild(args, tmpdir, specfile):
         cmd.append('--quiet')
     for define in args.define:
         cmd.append('--define')
-        cmd.append(define)
+        cmd.append(" ".join(define))
     cmd.append('--define')
     cmd.append('_sourcedir %s' % tmpdir)
     cmd.append('-bs')

--- a/planex/cmd/makesrpm.py
+++ b/planex/cmd/makesrpm.py
@@ -14,7 +14,7 @@ import tempfile
 
 import argparse
 import argcomplete
-from planex.cmd.args import common_base_parser, rpm_define_parser
+import planex.cmd.args
 from planex.spec import Spec
 from planex.link import Link
 from planex.patchqueue import Patchqueue
@@ -27,13 +27,12 @@ def parse_args_or_exit(argv=None):
     """
     parser = argparse.ArgumentParser(
         description='Pack sources and patchqueues into a source RPM',
-        parents=[common_base_parser(), rpm_define_parser()])
+        parents=[planex.cmd.args.common_base_parser(),
+                 planex.cmd.args.rpm_define_parser(),
+                 planex.cmd.args.keeptmp_parser()])
     parser.add_argument("spec", metavar="SPEC", help="Spec file")
     parser.add_argument("sources", metavar="SOURCE/PATCHQUEUE", nargs='*',
                         help="Source and patchqueue files")
-    parser.add_argument(
-        "--keeptmp", action="store_true",
-        help="keep temporary files")
     argcomplete.autocomplete(parser)
 
     parsed_args = parser.parse_args(argv)

--- a/planex/cmd/makesrpm.py
+++ b/planex/cmd/makesrpm.py
@@ -14,7 +14,7 @@ import tempfile
 
 import argparse
 import argcomplete
-from planex.cmd.args import add_common_parser_options
+from planex.cmd.args import common_base_parser
 from planex.spec import Spec
 from planex.link import Link
 from planex.patchqueue import Patchqueue
@@ -26,8 +26,8 @@ def parse_args_or_exit(argv=None):
     Parse command line options
     """
     parser = argparse.ArgumentParser(
-        description='Pack sources and patchqueues into a source RPM')
-    add_common_parser_options(parser)
+        description='Pack sources and patchqueues into a source RPM',
+        parents=[common_base_parser()])
     parser.add_argument("spec", metavar="SPEC", help="Spec file")
     parser.add_argument("sources", metavar="SOURCE/PATCHQUEUE", nargs='*',
                         help="Source and patchqueue files")

--- a/planex/cmd/manifest.py
+++ b/planex/cmd/manifest.py
@@ -11,7 +11,7 @@ import os
 
 import argcomplete
 
-from planex.cmd.args import add_common_parser_options
+from planex.cmd.args import common_base_parser
 from planex.util import setup_logging
 from planex.link import Link
 from planex.spec import Spec
@@ -22,10 +22,9 @@ def parse_args_or_exit(argv=None):
     """Parse command line options"""
 
     parser = argparse.ArgumentParser(
-        description='Generate manifest in JSON format from spec/link files'
+        description='Generate manifest in JSON format from spec/link files',
+        parents=[common_base_parser()]
     )
-
-    add_common_parser_options(parser)
 
     parser.add_argument(
         'specfile_path',

--- a/planex/cmd/mock.py
+++ b/planex/cmd/mock.py
@@ -13,7 +13,7 @@ from uuid import uuid4
 
 import argparse
 import argcomplete
-from planex.cmd.args import add_common_parser_options
+from planex.cmd.args import common_base_parser
 
 
 def parse_args_or_exit(argv=None):
@@ -21,8 +21,8 @@ def parse_args_or_exit(argv=None):
     Parse command line options
     """
     parser = argparse.ArgumentParser(
-        description='Planex build system in a chroot (a mock wrapper)')
-    add_common_parser_options(parser)
+        description='Planex build system in a chroot (a mock wrapper)',
+        parents=[common_base_parser()])
     parser.add_argument(
         "--configdir", metavar="CONFIGDIR", default="/etc/mock",
         help="Change where the config files are found")

--- a/planex/cmd/mock.py
+++ b/planex/cmd/mock.py
@@ -13,7 +13,7 @@ from uuid import uuid4
 
 import argparse
 import argcomplete
-from planex.cmd.args import common_base_parser, rpm_define_parser
+import planex.cmd.args
 
 
 def parse_args_or_exit(argv=None):
@@ -22,7 +22,9 @@ def parse_args_or_exit(argv=None):
     """
     parser = argparse.ArgumentParser(
         description='Planex build system in a chroot (a mock wrapper)',
-        parents=[common_base_parser(), rpm_define_parser()])
+        parents=[planex.cmd.args.common_base_parser(),
+                 planex.cmd.args.rpm_define_parser(),
+                 planex.cmd.args.keeptmp_parser()])
     parser.add_argument(
         "--configdir", metavar="CONFIGDIR", default="/etc/mock",
         help="Change where the config files are found")
@@ -32,9 +34,6 @@ def parse_args_or_exit(argv=None):
     parser.add_argument(
         "--resultdir", metavar="RESULTDIR", default=None,
         help="Path for resulting files to be put")
-    parser.add_argument(
-        "--keeptmp", action="store_true",
-        help="Keep temporary files")
     parser.add_argument(
         "--init", action="store_true",
         help="initialize the chroot, do not build anything")

--- a/planex/cmd/mock.py
+++ b/planex/cmd/mock.py
@@ -13,7 +13,7 @@ from uuid import uuid4
 
 import argparse
 import argcomplete
-from planex.cmd.args import common_base_parser
+from planex.cmd.args import common_base_parser, rpm_define_parser
 
 
 def parse_args_or_exit(argv=None):
@@ -22,7 +22,7 @@ def parse_args_or_exit(argv=None):
     """
     parser = argparse.ArgumentParser(
         description='Planex build system in a chroot (a mock wrapper)',
-        parents=[common_base_parser()])
+        parents=[common_base_parser(), rpm_define_parser()])
     parser.add_argument(
         "--configdir", metavar="CONFIGDIR", default="/etc/mock",
         help="Change where the config files are found")
@@ -35,10 +35,6 @@ def parse_args_or_exit(argv=None):
     parser.add_argument(
         "--keeptmp", action="store_true",
         help="Keep temporary files")
-    parser.add_argument(
-        "-D", "--define", default=[], action="append",
-        help="--define='MACRO EXPR' \
-              define MACRO with value EXPR for the build")
     parser.add_argument(
         "--init", action="store_true",
         help="initialize the chroot, do not build anything")
@@ -94,7 +90,7 @@ def mock(args, tmp_config_dir, *extra_params):
         cmd += ["--resultdir", args.resultdir]
 
     for define in args.define:
-        cmd += ['--define', define]
+        cmd += ['--define', " ".join(define)]
 
     cmd.extend(extra_params)
     # mock produces more output when stderr isatty, so use a pty to fake that

--- a/planex/cmd/patchqueue.py
+++ b/planex/cmd/patchqueue.py
@@ -19,7 +19,7 @@ from planex.spec import Spec
 import planex.git as git
 import planex.tarball as tarball
 import planex.util as util
-from planex.cmd.args import common_base_parser
+from planex.cmd.args import common_base_parser, keeptmp_parser
 
 
 def parse_args_or_exit(argv=None):
@@ -28,13 +28,11 @@ def parse_args_or_exit(argv=None):
     """
     parser = argparse.ArgumentParser(
         description='Create a patchqueue from a linked Git repository',
-        parents=[common_base_parser()])
+        parents=[common_base_parser(), keeptmp_parser()])
     parser.add_argument("link", metavar="LINK", help="link file")
     parser.add_argument("tarball", metavar="TARBALL", help="tarball")
     parser.add_argument("--repos", default="repos",
                         help="Local repository directory")
-    parser.add_argument("--keeptmp", action="store_true",
-                        help="Do not clean up working directory")
     argcomplete.autocomplete(parser)
     return parser.parse_args(argv)
 

--- a/planex/cmd/patchqueue.py
+++ b/planex/cmd/patchqueue.py
@@ -19,7 +19,7 @@ from planex.spec import Spec
 import planex.git as git
 import planex.tarball as tarball
 import planex.util as util
-from planex.cmd.args import add_common_parser_options
+from planex.cmd.args import common_base_parser
 
 
 def parse_args_or_exit(argv=None):
@@ -27,8 +27,8 @@ def parse_args_or_exit(argv=None):
     Parse command line options
     """
     parser = argparse.ArgumentParser(
-        description='Create a patchqueue from a linked Git repository')
-    add_common_parser_options(parser)
+        description='Create a patchqueue from a linked Git repository',
+        parents=[common_base_parser()])
     parser.add_argument("link", metavar="LINK", help="link file")
     parser.add_argument("tarball", metavar="TARBALL", help="tarball")
     parser.add_argument("--repos", default="repos",

--- a/planex/cmd/pin.py
+++ b/planex/cmd/pin.py
@@ -9,7 +9,7 @@ import json
 import os
 import sys
 
-from planex.cmd.args import add_common_parser_options
+from planex.cmd.args import common_base_parser
 from planex.link import Link
 from planex.repository import Repository
 from planex.spec import Spec
@@ -124,8 +124,8 @@ def parse_args_or_exit(argv=None):
     parser = argparse.ArgumentParser(
         description="Create a .pin file pointing to a repository "
                     "in $CWD/repos. You must run "
-                    "this tool from the root of a spec repository.")
-    add_common_parser_options(parser)
+                    "this tool from the root of a spec repository.",
+        parents=[common_base_parser()])
     parser.add_argument("package", help="package name")
     parser.add_argument("--url", metavar="URL", default=None,
                         help="Source repository URL."


### PR DESCRIPTION
argparse has a 'parents' mechanism which allows parsers to inherit options
from each other.   Use this instead of passing newly-created parsers to
a function which adds common options to them.

Signed-off-by: Euan Harris <euan.harris@citrix.com>