### PR TITLE
Makefile.rules: add RPMBUILD_EXTRA_FLAGS

### DIFF
--- a/planex/Makefile.rules
+++ b/planex/Makefile.rules
@@ -33,7 +33,7 @@ EXTRACT ?= planex-extract
 EXTRACT_FLAGS ?= $(EXTRACT_EXTRA_FLAGS)
 
 RPMBUILD ?= planex-make-srpm
-RPMBUILD_FLAGS ?= ${QUIET+--quiet} $(RPM_DEFINES)
+RPMBUILD_FLAGS ?= ${QUIET+--quiet} $(RPM_DEFINES) $(RPMBUILD_EXTRA_FLAGS)
 
 CREATEREPO ?= createrepo
 CREATEREPO_FLAGS ?= ${QUIET+--quiet}


### PR DESCRIPTION
Append the optional RPMBUILD_EXTRA_FLAGS to RPMBUILD_FLAGS to allow
the caller to add options like --nocheck.