### PR TITLE
patchqueue: Do not pass parameters which are properties of other parameters

### DIFF
--- a/planex/cmd/patchqueue.py
+++ b/planex/cmd/patchqueue.py
@@ -59,8 +59,7 @@ def assemble_patchqueue(tmpdir, link, repo, start_tag, end_tag):
             series.write(os.path.basename(patch) + "\n")
 
 
-# pylint: disable=R0913
-def assemble_extra_sources(tmpdir, repo, spec, link, sources, patches):
+def assemble_extra_sources(tmpdir, repo, spec, link):
     """
     Assemble the non-patchqueue sources in the working directory.
     """
@@ -68,13 +67,13 @@ def assemble_extra_sources(tmpdir, repo, spec, link, sources, patches):
         copy_to_tmpdir(tmpdir, spec.path, link.specfile)
 
     if link.sources is not None:
-        for source in sources:
+        for source in spec.local_sources():
             source_path = os.path.join(repo, link.sources, source)
             dest_path = os.path.join(link.sources, source)
             copy_to_tmpdir(tmpdir, source_path, dest_path)
 
     if link.patches is not None:
-        for patch in patches:
+        for patch in spec.local_patches():
             source_path = os.path.join(repo, link.patches, patch)
             dest_path = os.path.join(tmpdir, link.patches, patch)
             copy_to_tmpdir(tmpdir, source_path, dest_path)
@@ -130,8 +129,7 @@ def main(argv=None):
     try:
         tmpdir = tempfile.mkdtemp(prefix="px-pq-")
         assemble_patchqueue(tmpdir, link, repo, start_tag, end_tag)
-        assemble_extra_sources(tmpdir, repo, spec, link,
-                               spec.local_sources(), spec.local_patches())
+        assemble_extra_sources(tmpdir, repo, spec, link)
         with FileUpdate(args.tarball) as outfile:
             tarball.make(tmpdir, outfile)
 


### PR DESCRIPTION
assemble_extra_sources() takes 'sources' and 'patches' parameters which
are only ever passed the results of calling accessor functions on the
spec object.   Since the spec object is passed to the function as well,
it can call them directly.

Signed-off-by: Euan Harris <euan.harris@citrix.com>