### PR TITLE
depend: Fix bad logical code structure

### DIFF
--- a/planex/cmd/depend.py
+++ b/planex/cmd/depend.py
@@ -181,10 +181,10 @@ def main(argv=None):
             srpmpath = spec.source_package_path()
             patchpath = spec.expand_macro("%_sourcedir/patches.tar")
             print '%s: %s' % (srpmpath, patchpath)
-        if spec.name() in pins:
-            print '%s: %s' % (srpmpath, pins[spec.name()])
-        elif spec.name() in links:
-            print '%s: %s' % (srpmpath, links[spec.name()])
+            if spec.name() in pins:
+                print '%s: %s' % (srpmpath, pins[spec.name()])
+            elif spec.name() in links:
+                print '%s: %s' % (srpmpath, links[spec.name()])
         download_rpm_sources(spec)
         build_rpm_from_srpm(spec)
         if args.buildrequires:


### PR DESCRIPTION
These conditional statements can only be executed if the earlier
    conditional is also executed.   Since the later clauses are subsets
    of the earlier one, the current code cannot go wrong when executed;
    this commit simply changes the structure of the code to match.

Signed-off-by: Euan Harris <euan.harris@citrix.com>