### PR TITLE
Remove unused methods

### DIFF
--- a/planex/git.py
+++ b/planex/git.py
@@ -33,32 +33,6 @@ def dotgitdir_of_path(repo):
         raise Exception("Not a git repository: '%s'" % repo)
 
 
-def describe(repo, treeish="HEAD"):
-    """
-    Return an RPM compatible version string for a git repo at a given commit
-    """
-    dotgitdir = dotgitdir_of_path(repo)
-
-    # First, get the hash of the commit
-    cmd = ["git", "--git-dir=%s" % dotgitdir, "rev-parse", treeish]
-    sha = run(cmd)['stdout'].strip()
-
-    # Now lets describe that hash
-    cmd = ["git", "--git-dir=%s" % dotgitdir, "describe", "--tags", sha]
-    description = run(cmd, check=False)['stdout'].strip()
-
-    # if there are no tags, use the number of commits
-    if description == "":
-        cmd = ["git", "--git-dir=%s" % dotgitdir, "log", "--oneline", sha]
-        commits = run(cmd)['stdout'].strip()
-        description = str(len(commits.splitlines()))
-
-    # replace '-' with '+' in description to not confuse rpm
-    match = re.search("[^0-9]*", description)
-    matchlen = len(match.group())
-    return description[matchlen:].replace('-', '+')
-
-
 def archive(repo, commit_hash, output, prefix=None):
     """
     Archive a git repo at a given commit with a specified version prefix.

--- a/planex/git.py
+++ b/planex/git.py
@@ -55,14 +55,6 @@ def tags(repo):
     return run(["git", "--git-dir=%s" % dotgitdir, "tag"])['stdout'].split()
 
 
-def current_branch(repo):
-    """
-    Return the name of the current branch on repo. Requires git 1.7+.
-    """
-    return run(["git", "--work-tree=%s" % repo, "rev-parse",
-                "--abbrev-ref", "HEAD"])['stdout'].strip()
-
-
 def format_patch(repo, startref, endref, target_dir):
     """
     Write patches from ref to HEAD out to target_dir.


### PR DESCRIPTION
git.describe() and git.current_branch()

If we need these in future, we should use [GitPython](http://gitpython.readthedocs.io/en/stable/index.html).