### PR TITLE
planex-clone: Add option to skip cloning a patchqueue's base repository

### DIFF
--- a/planex/cmd/clone.py
+++ b/planex/cmd/clone.py
@@ -19,8 +19,6 @@ def parse_args_or_exit(argv=None):
     Parse command line options
     """
     parser = argparse.ArgumentParser(description='Clone sources')
-    parser.add_argument("-P", "--pins-dir", default="PINS",
-                        help="Directory containing pin overlays")
     parser.add_argument("--jenkins", action="store_true",
                         help="Print Jenkinsfile fragment")
     parser.add_argument("--skip-base", dest="clone_base",

--- a/planex/cmd/clone.py
+++ b/planex/cmd/clone.py
@@ -23,6 +23,9 @@ def parse_args_or_exit(argv=None):
                         help="Directory containing pin overlays")
     parser.add_argument("--jenkins", action="store_true",
                         help="Print Jenkinsfile fragment")
+    parser.add_argument("--skip-base", dest="clone_base",
+                        default=True, action="store_false",
+                        help="Do not clone the base repository")
     parser.add_argument("--credentials", metavar="CREDS", default="",
                         help="Credentials")
     parser.add_argument(
@@ -130,7 +133,7 @@ def main(argv=None):
                 util.makedirs(args.repos)
                 pq_repo = clone(pin.url, args.repos, pin.commitish)
 
-                if pin.base is not None:
+                if args.clone_base and pin.base:
                     print("Cloning %s" % pin.base)
                     base_repo = clone(pin.base, args.repos, pin.base_commitish)
                     apply_patchqueue(base_repo, pq_repo, pin.patchqueue)


### PR DESCRIPTION
This new option allows the user to avoid cloning the base repository and applying the patchqueue to it.   This can be an expensive operation, and is not necessary if the user does not want to work on the package and instead just wants to build it.