### PR TITLE
depend: Check patchqueue for sources and patches

### DIFF
--- a/planex/cmd/depend.py
+++ b/planex/cmd/depend.py
@@ -44,7 +44,7 @@ def build_srpm_from_spec(spec, lnk=None):
         if source.scheme in ["http", "https", "file", "ftp"]:
             # Source was downloaded to _build/SOURCES
             print('%s: %s' % (srpmpath, path))
-        elif lnk and lnk.sources:
+        elif lnk and (lnk.sources is not None or lnk.patches is not None):
             # Use sources from patchqueue
             pass
         else:


### PR DESCRIPTION
It is valid to set sources to "" in a link file - this means "sources
can be found in the root of the tarball".   Also, some packages have
extra patches in their patchqueues but no extra sources.

Signed-off-by: Euan Harris <euan.harris@citrix.com>