### PR TITLE
setup.py: remove include_package_data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,6 @@ from setuptools import setup
 setup(name='planex',
       version='2.1.0',
       packages=['planex', 'planex.cmd'],
-      include_package_data=True,
       package_data={'planex': ['Makefile.rules']},
       entry_points={
           'console_scripts': [


### PR DESCRIPTION
There is already an explicit map of files to include and defining both
prevents them from being included in a source distribution. See
https://stackoverflow.com/questions/7522250/how-to-include-package-data-with-setuptools-distribute

Signed-off-by: Simon Rowe <simon.rowe@eu.citrix.com>