### PR TITLE
mock: Fix RPMS top-level link

### DIFF
--- a/planex/Makefile.rules
+++ b/planex/Makefile.rules
@@ -140,7 +140,7 @@ $(TOPDIR)/SOURCES/%/patches.tar: $(PINSDIR)/%.pin FORCE
 %.rpm:
 	@echo [MOCK] $<
 	$(AT) mkdir -p $(@D)
-	$(AT) ln -sf $(@D)
+	$(AT) ln -sf $(TOPDIR)/RPMS
 	$(AT)$(MOCK) $(MOCK_FLAGS) --rebuild $<
 
 


### PR DESCRIPTION
After 4fc2f628, links were created to the x86_64 and noarch subdirectories
instead of the RPMS directory.

Fixes #457, although in future we would like to remove these symlinks altogether.

Signed-off-by: Euan Harris <euan.harris@citrix.com>