### PR TITLE
Remove RPMS and MANIFESTS links

### DIFF
--- a/planex/Makefile.rules
+++ b/planex/Makefile.rules
@@ -71,13 +71,7 @@ endif
 .PHONY: all rpms
 all: $(RPMS)
 
-$(RPMS): RPMS MANIFESTS $(MOCK_CONFIGDIR)/$(MOCK_ROOT).cfg
-
-RPMS:
-	ln -s $(TOPDIR)/RPMS RPMS
-
-MANIFESTS:
-	ln -s $(TOPDIR)/MANIFESTS MANIFESTS
+$(RPMS): $(MOCK_CONFIGDIR)/$(MOCK_ROOT).cfg
 
 $(TOPDIR)/RPMS/repodata/repomd.xml: $(RPMS)
 	$(AT)$(CREATEREPO) $(CREATEREPO_FLAGS) $(TOPDIR)/RPMS
@@ -89,7 +83,7 @@ srpms: $(SRPMS)
 
 .PHONY: clean
 clean:
-	rm -rf $(TOPDIR) RPMS MANIFESTS
+	rm -rf $(TOPDIR)
 
 
 ############################################################################

--- a/planex/Makefile.rules
+++ b/planex/Makefile.rules
@@ -39,6 +39,7 @@ CREATEREPO_FLAGS ?= ${QUIET+--quiet}
 
 MOCK ?= planex-build-mock
 MOCK_FLAGS ?= ${QUIET+--quiet} \
+              $(RPM_DEFINES) \
               --configdir=$(MOCK_CONFIGDIR) \
               --root=$(MOCK_ROOT) \
               --resultdir=$(@D) \

--- a/planex/cmd/mock.py
+++ b/planex/cmd/mock.py
@@ -91,8 +91,12 @@ def mock(args, tmp_config_dir, *extra_params):
     if args.resultdir is not None:
         cmd += ["--resultdir", args.resultdir]
 
-    for define in args.define:
-        cmd += ['--define', " ".join(define)]
+    for key, value in args.define:
+        # _topdir should only be used to figure out the RPM paths outside
+        # the chroot.  Defining it inside the mock chroot confuses the
+        # build.
+        if key != "_topdir":
+            cmd += ['--define', '%s %s' % (key, value)]
 
     cmd.extend(extra_params)
     # mock produces more output when stderr isatty, so use a pty to fake that

--- a/planex/cmd/mock.py
+++ b/planex/cmd/mock.py
@@ -3,6 +3,7 @@ planex-build-mock: Wrapper around mock
 """
 from __future__ import print_function
 
+from collections import OrderedDict
 import os
 import pty
 import shutil
@@ -14,6 +15,8 @@ from uuid import uuid4
 import argparse
 import argcomplete
 import planex.cmd.args
+from planex.spec import rpm_macros
+import rpm
 
 
 def parse_args_or_exit(argv=None):
@@ -174,7 +177,9 @@ def main(argv=None):
                 config_out_path,
                 tmpdir,
                 args.loopback_config_extra)
-            createrepo(os.path.join(os.getcwd(), "RPMS"), tmpdir, args.quiet)
+            with rpm_macros(OrderedDict(args.define)):
+                rpmdir = os.path.abspath(rpm.expandMacro("%_rpmdir"))
+                createrepo(rpmdir, tmpdir, args.quiet)
             mock(args, config, "--rebuild", *args.srpms)
 
     except subprocess.CalledProcessError as cpe:


### PR DESCRIPTION
These changes remove the last assumptions that the build outputs will be written somewhere in the spec file repo checkout.   This makes it possible to set TOPDIR to an external path and keep the specs pristine, and may also help with #361.

Fixes #211 