### PR TITLE
depend: Make a package depend on its Requires as well as its BuildRequires

### DIFF
--- a/planex/cmd/depend.py
+++ b/planex/cmd/depend.py
@@ -102,7 +102,11 @@ def buildrequires_for_rpm(spec, provides_to_rpm):
     Generate build dependency rules between binary RPMs
     """
     rpmpath = spec.binary_package_paths()[-1]
-    for buildreq in spec.buildrequires():
+    # Package's Requires must exist for it to be installed as a
+    # BuildRequire of a later package, so we make it depend on
+    # Requires as well as BuildRequires to ensure they are built.
+    buildreqs = (spec.buildrequires() | spec.requires()) - spec.provides()
+    for buildreq in buildreqs:
         # Some buildrequires come from the system repository
         if buildreq in provides_to_rpm:
             buildreqrpm = provides_to_rpm[buildreq]

--- a/planex/spec.py
+++ b/planex/spec.py
@@ -184,6 +184,15 @@ class Spec(object):
 
         return paths
 
+    # RPM runtime dependencies.   These are not required to build this
+    # package, but will need to be installed when building any other
+    # package which BuildRequires this one.
+    def requires(self):
+        """Return the set of packages needed by this package at runtime
+           (Requires)"""
+        return set.union(*[set(p.header['REQUIRES'])
+                           for p in self.spec.packages])
+
     # RPM build dependencies.   The 'requires' key for the *source* RPM is
     # actually the 'buildrequires' key from the spec
     def buildrequires(self):

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -66,6 +66,12 @@ class RpmTests(unittest.TestCase):
              "./SOURCES/ocaml-cohttp/cohttp0.patch",
              "./SOURCES/ocaml-cohttp/cohttp1.patch"])
 
+    def test_requires(self):
+        """Package runtime requirements are correct"""
+        self.assertEqual(
+            self.spec.requires(),
+            set(["ocaml", "ocaml-findlib"]))
+
     def test_buildrequires(self):
         """Package build-time requirements are correct"""
         self.assertEqual(


### PR DESCRIPTION
To build package A, mock needs to install all the package's build-time
requirements (BuildRequires). It does not need to install the package's
runtime requirements (Requires). However, to build package B, which
depends on A, mock must install A's runtime requirements. This causes
problems if A's runtime requirements come from the same spec repository as
A itself. planex-depend does not produce a Makefile dependency which will
cause A's runtime dependencies to be build before B is built, so it is
the luck of the draw whether those packages exist at the time B is built.

Technically, planex-depend should make B have a build dependency on
A's runtime dependencies, however it is easier to make A depend on its
own runtime dependencies, even though they are not strictly required in
order to build it.

As with BuildRequires, if a runtime dependency is not provided by any
of the specs we are building, we will assume that the dependency comes
from the environment and no Makefile rule will be created.

Signed-off-by: Euan Harris <euan.harris@citrix.com>

Fixes #474 