### PR TITLE
Handle building components that have three source

### DIFF
--- a/planex/cmd/makesrpm.py
+++ b/planex/cmd/makesrpm.py
@@ -42,7 +42,8 @@ def parse_args_or_exit(argv=None):
     if links:
         parsed_args.link = Link(links[0])
 
-    patchqueues = [arg for arg in argv if arg.endswith("patches.tar")]
+    patch_re = re.compile(r'.*patches\d*.tar$')
+    patchqueues = [arg for arg in argv if patch_re.match(arg)]
     parsed_args.patchqueue = None
     if patchqueues:
         parsed_args.patchqueue = patchqueues[0]

--- a/planex/cmd/manifest.py
+++ b/planex/cmd/manifest.py
@@ -111,7 +111,7 @@ def generate_manifest(spec, link=None, pin=None):
 
         manifest['spec']['source' + str(i)] = {'url': url, 'sha1': sha1}
 
-    if link is not None:
+    if link is not None and link.url:
         repo_ref = Repository(link.url)
         sha1 = repo_ref.sha1
         manifest['lnk'] = {'url': link.url, 'sha1': sha1}

--- a/planex/link.py
+++ b/planex/link.py
@@ -3,6 +3,14 @@ Classes for dealing with pin and link files
 """
 
 import json
+import re
+
+
+class UnsupportedProperty(RuntimeError):
+    """ Error to be raised if we're asked for properties not present in this
+    schema version
+    """
+    pass
 
 
 class Link(object):
@@ -12,6 +20,12 @@ class Link(object):
         self.path = path
         with open(path) as fileh:
             self.link = json.load(fileh)
+
+    @property
+    def schema_version(self):
+        """Return the schema version of the link file"""
+        # Default to v1 if not present, for legacy lnks
+        return int(self.link.get('SchemaVersion', 1))
 
     @property
     def linkpath(self):
@@ -32,6 +46,8 @@ class Link(object):
     @property
     def patchqueue(self):
         """Return the path to the patchqueue inside the patchqueue tarball"""
+        if self.schema_version > 1:
+            raise UnsupportedProperty('patchqueue only supported on v1')
         return self.link.get('patchqueue', None)
 
     @property
@@ -54,3 +70,34 @@ class Link(object):
         """Return the base repository on top of which to apply the
            patchqueue"""
         return self.link.get('base', None)
+
+    @property
+    def patch_sources(self):
+        """Return the ordered set of patch source definitions"""
+        if self.schema_version < 2:
+            raise UnsupportedProperty('patch_sourcess requries at least'
+                                      'schema version 2')
+
+        patch_matcher = re.compile(r'patch\d+', re.IGNORECASE)
+        return {k: v for k, v
+                in self.link.iteritems()
+                if patch_matcher.match(k)}
+
+    @property
+    def patchqueue_sources(self):
+        """Return the ordered set of patchqueue definitions"""
+        if self.schema_version < 2:
+            raise UnsupportedProperty('patch_sourcess requries at least'
+                                      'schema version 2')
+
+        patch_matcher = re.compile(r'patchqueue\d+', re.IGNORECASE)
+        return {k: v for k, v
+                in self.link.iteritems()
+                if patch_matcher.match(k)}
+
+    @property
+    def has_patches(self):
+        """ Test if the lnk defines patches """
+        return ((self.schema_version == 1 and self.patches is not None) or
+                (self.schema_version >= 2 and
+                 (self.patch_sources or self.patchqueue_sources)))

--- a/planex/patchqueue.py
+++ b/planex/patchqueue.py
@@ -91,12 +91,15 @@ def rewrite_spec(spec, patches, patchnum):
     """
     done = False
     for line in spec.spectext:
-        if not done and line.upper().startswith('SOURCE'):
+        yield line
+        upper_line = line.upper()
+        if not done and (
+                (upper_line.startswith('SOURCE') and patchnum == -1) or
+                (upper_line.startswith('PATCH%s' % patchnum))):
             for patch in patches:
                 patchnum += 1
                 yield "Patch%d: %s\n" % (patchnum, patch)
             done = True
-        yield line
 
 
 def expand_patchqueue(spec, series):

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -1,0 +1,110 @@
+"""
+Tests for the class representing a link (lnk) or pin file
+"""
+import unittest
+import mock
+
+import planex.link
+
+
+class TestLink(unittest.TestCase):
+    """ Unit tests for the Link class """
+
+    v1_link = """
+{
+    "URL": "https://code.citrite.net/rest/archive/latest/projects/XS/repos/sm.pg/archive?at=1.14&format=tar#/sm.patches.tar",
+    "patchqueue": "master"
+}
+"""  # nopep8
+
+    v2_link = """
+{
+    "SchemaVersion": "2",
+    "Source0":
+    {
+        "URL": "https://code.citrite.net/rest/archive/latest/projects/XSU/repos/sbd/archive?at=v1.3.0&format=tar"
+    },
+    "Source1":
+    {
+        "URL": "Blah"
+    },
+    "Patch0":
+    {
+        "URL": "https://code.citrite.net/rest/archive/latest/projects/~MARKSY/repos/sbd-centos/archive?at=f46b0e608f5&format=tar",
+        "patches": "SOURCES"
+    },
+    "PatchQueue0":
+    {
+        "URL": "https://code.citrite.net/rest/archive/latest/projects/~MARKSY/repos/sbd.pg/archive?at=f4d3fb5&format=tar",
+        "patchqueue": "master"
+    }
+}
+"""  # nopep8
+
+    @mock.patch('planex.link.open', mock.mock_open(read_data=v2_link))
+    def test_schema_v2(self):
+        """ Test that the schema version of a v2 lnk is 2 """
+        link = planex.link.Link('test_v2.lnk')
+
+        self.assertEquals(2, link.schema_version)
+
+    @mock.patch('planex.link.open', mock.mock_open(read_data=v1_link))
+    def test_schema_v1(self):
+        """ Test that the schema version of a v1 lnk is coerced to 1 """
+        link = planex.link.Link('test_v1.lnk')
+
+        self.assertEquals(1, link.schema_version)
+
+    @mock.patch('planex.link.open', mock.mock_open(read_data=v1_link))
+    def test_patch_sources_v1(self):
+        """ Test that we get an error if asking for patch_sources on v1"""
+
+        link = planex.link.Link('test_v1.lnk')
+        sources = None
+        with self.assertRaises(planex.link.UnsupportedProperty):
+            sources = link.patch_sources
+        self.assertIsNone(sources)
+
+    @mock.patch('planex.link.open', mock.mock_open(read_data=v1_link))
+    def test_patchqueue_sources_v1(self):
+        """ Test that we get an error if asking for patchqueue_sources on v1"""
+
+        link = planex.link.Link('test_v1.lnk')
+        sources = None
+        with self.assertRaises(planex.link.UnsupportedProperty):
+            sources = link.patchqueue_sources
+        self.assertIsNone(sources)
+
+    @mock.patch('planex.link.open', mock.mock_open(read_data=v2_link))
+    def test_patch_sources_v2(self):
+        """ Test that we get sources if asking for patch_sources on v2"""
+
+        link = planex.link.Link('test_v2.lnk')
+        sources = link.patch_sources
+        self.assertIn('Patch0', sources)
+
+    @mock.patch('planex.link.open', mock.mock_open(read_data=v2_link))
+    def test_patchqueue_sources_v2(self):
+        """ Test that we get sources if asking for patchqueue_sources on v2"""
+
+        link = planex.link.Link('test_v2.lnk')
+        sources = link.patchqueue_sources
+        self.assertIn('PatchQueue0', sources)
+
+    @mock.patch('planex.link.open', mock.mock_open(read_data=v1_link))
+    def test_patchqueue_v1(self):
+        """ Test that we get data for patchqueue on v1"""
+
+        link = planex.link.Link('test_v1.lnk')
+        patchqueue = link.patchqueue
+        self.assertEqual('master', patchqueue)
+
+    @mock.patch('planex.link.open', mock.mock_open(read_data=v2_link))
+    def test_patchqueue_v2(self):
+        """ Test that we get an error for patchqueue on v2"""
+
+        link = planex.link.Link('test_v2.lnk')
+        patchqueue = None
+        with self.assertRaises(planex.link.UnsupportedProperty):
+            patchqueue = link.patchqueue
+        self.assertIsNone(patchqueue)


### PR DESCRIPTION
Handle building components that consume pristine source (as specified by the spec), distro patches listed as additional patches in the specfile and local patchqueues.