### PR TITLE
makesrpm: Avoid unlink races in ln -sf

### DIFF
--- a/planex/Makefile.rules
+++ b/planex/Makefile.rules
@@ -68,9 +68,15 @@ endif
 .DELETE_ON_ERROR:
 
 .PHONY: all rpms
-all: $(TOPDIR) $(RPMS)
+all: $(RPMS)
 
-$(RPMS): $(MOCK_CONFIGDIR)/$(MOCK_ROOT).cfg
+$(RPMS): RPMS MANIFESTS $(MOCK_CONFIGDIR)/$(MOCK_ROOT).cfg
+
+RPMS:
+	ln -s $(TOPDIR)/RPMS RPMS
+
+MANIFESTS:
+	ln -s $(TOPDIR)/MANIFESTS MANIFESTS
 
 $(TOPDIR)/RPMS/repodata/repomd.xml: $(RPMS)
 	$(AT)$(CREATEREPO) $(CREATEREPO_FLAGS) $(TOPDIR)/RPMS
@@ -92,7 +98,6 @@ clean:
 $(TOPDIR)/MANIFESTS/%.json:
 	@echo [MANIFEST] $@
 	$(AT) mkdir -p $(@D)
-	$(AT) ln -sf $(@D)
 	$(AT)$(MANIFEST) $(MANIFEST_FLAGS) $^ > $@
 
 
@@ -140,7 +145,6 @@ $(TOPDIR)/SOURCES/%/patches.tar: $(PINSDIR)/%.pin FORCE
 %.rpm:
 	@echo [MOCK] $<
 	$(AT) mkdir -p $(@D)
-	$(AT) ln -sf $(TOPDIR)/RPMS
 	$(AT)$(MOCK) $(MOCK_FLAGS) --rebuild $<
 
 


### PR DESCRIPTION
A race can occur when calling ln -sf in older versions of GNU coreutils (and
in busybox):

   http://git.savannah.gnu.org/gitweb/?p=coreutils.git;a=commit;h=376967889ed7ed561e46ff6d88a66779db62737a

We seem to be hitting this race because we use ln -sf to create the
RPMS and MANIFESTS top-level symlinks for every target.   Two racing
ln invocations try to remove the existing symlink, one succeeds and the
other fails with the following message:

  ln: cannot remove './RPMS': No such file or directory

This does not happen all the time because the first ln may have created
its link, which the second then deletes.

This commit switches back to the previous behaviour of creating these
symlinks at the start of the build.   This has caused problems in the
past (bug 211) so we intend eventually to remove these links altogether.

Signed-off-by: Euan Harris <euan.harris@citrix.com>