### PR TITLE
mksrpm: Fix scoping error in get_commit_id()

### DIFF
--- a/planex/cmd/makesrpm.py
+++ b/planex/cmd/makesrpm.py
@@ -92,9 +92,9 @@ def get_commit_id(info_file):
     """
     Read the commit id from the .gitarchive-info file
     """
-    changeset = re.compile(r'^Changeset: (.*)$')
+    regex = re.compile(r'^Changeset: (.*)$')
     for line in info_file:
-        match = changeset.match(line)
+        match = regex.match(line)
         if match:
             changeset = match.group(1)
             # Skip if .gitarchive-info hasn't passed through `git archive`


### PR DESCRIPTION
The variable changeset gets used first as a regex, then becomes the content of
the first successful match.  If the loop hits the continue path, execution
blows up with:

Traceback (most recent call last):
  File "/usr/bin/planex-make-srpm", line 9, in <module>
    load_entry_point('planex==2.1.1', 'console_scripts', 'planex-make-srpm')()
  File "/usr/lib/python2.7/site-packages/planex/cmd/makesrpm.py", line 191, in main
    args.sources, args.patchqueue)
  File "/usr/lib/python2.7/site-packages/planex/cmd/makesrpm.py", line 146, in populate_working_directory
    extract_commit(source, manifests)
  File "/usr/lib/python2.7/site-packages/planex/cmd/makesrpm.py", line 129, in extract_commit
    manifests[name.strip()] = get_commit_id(archive_info)
  File "/usr/lib/python2.7/site-packages/planex/cmd/makesrpm.py", line 81, in get_commit_id
    match = changeset.match(line)
AttributeError: 'str' object has no attribute 'match'

Rename one of the changeset variables to regex.

Signed-off-by: Andrew Cooper <andrew.cooper3@citrix.com>