### PR TITLE
Refactor helper methods in Spec

### DIFF
--- a/planex/spec.py
+++ b/planex/spec.py
@@ -18,18 +18,6 @@ import rpm
 # around methods such as 'provides'
 
 
-# Directories where rpmbuild/mock expects to find inputs
-# and writes outputs
-def rpmdir():
-    """Return the expanded value of the RPM %_rpmdir macro"""
-    return rpm.expandMacro('%_rpmdir')
-
-
-def srpmdir():
-    """Return the expanded value of the RPM %_srcrpmdir macro"""
-    return rpm.expandMacro('%_srcrpmdir')
-
-
 def flatten(lst):
     """Flatten a list of lists"""
     return sum(lst, [])
@@ -226,9 +214,7 @@ class Spec(object):
             # format. Unfortunately expanding that macro gives us a leading
             # 'src' that we don't want, so we strip that off
             srpmname = os.path.basename(rpm.expandMacro(self.srpmfilenamepat))
-            result = os.path.join(srpmdir(), srpmname)
-
-        return result
+            return rpm.expandMacro(os.path.join('%_srcrpmdir', srpmname))
 
     def binary_package_paths(self):
         """Return a list of binary packages built by this spec"""
@@ -245,9 +231,7 @@ class Spec(object):
 
             with rpm_macros(append_macros(self.macros, hardcoded_macros)):
                 rpmname = rpm.expandMacro(self.rpmfilenamepat)
-                result = os.path.join(rpmdir(), rpmname)
-
-            return result
+                return rpm.expandMacro(os.path.join('%_rpmdir', rpmname))
 
         return [rpm_name_from_header(pkg.header) for pkg in self.spec.packages]
 

--- a/planex/spec.py
+++ b/planex/spec.py
@@ -18,11 +18,6 @@ import rpm
 # around methods such as 'provides'
 
 
-def flatten(lst):
-    """Flatten a list of lists"""
-    return sum(lst, [])
-
-
 @contextlib.contextmanager
 def rpm_macros(macros):
     """Context manager to add and remove all macros in the dictionary"""
@@ -129,8 +124,8 @@ class Spec(object):
 
     def provides(self):
         """Return a list of package names provided by this spec"""
-        provides = flatten([pkg.header['provides'] + [pkg.header['name']]
-                            for pkg in self.spec.packages])
+        provides = sum([pkg.header['provides'] + [pkg.header['name']]
+                        for pkg in self.spec.packages], [])
 
         # RPM 4.6 adds architecture constraints to dependencies.  Drop them.
         provides = [re.sub(r'\(x86-64\)$', '', pkg) for pkg in provides]


### PR DESCRIPTION
* Extract logic to parse spec file quietly
* Inline three single-line helpers which were each used only once

Although the new `parse_spec_quietly()` helper is only used once, it is a substantial piece of code and extracting it simplifies `Spec.__init__()` considerably.