### PR TITLE
Refactor macro-handling wrappers

### DIFF
--- a/planex/cmd/mock.py
+++ b/planex/cmd/mock.py
@@ -3,7 +3,6 @@ planex-build-mock: Wrapper around mock
 """
 from __future__ import print_function
 
-from collections import OrderedDict
 import os
 import pty
 import shutil
@@ -181,7 +180,7 @@ def main(argv=None):
                 config_out_path,
                 tmpdir,
                 args.loopback_config_extra)
-            with rpm_macros(OrderedDict(args.define)):
+            with rpm_macros(dict(args.define)):
                 rpmdir = os.path.abspath(rpm.expandMacro("%_rpmdir"))
                 createrepo(rpmdir, tmpdir, args.quiet)
             mock(args, config, "--rebuild", *args.srpms)

--- a/planex/spec.py
+++ b/planex/spec.py
@@ -102,7 +102,6 @@ class Spec(object):
                         % (path, self.name()))
 
             self.rpmfilenamepat = rpm.expandMacro('%_build_name_fmt')
-            self.srpmfilenamepat = rpm.expandMacro('%_build_name_fmt')
 
     def specpath(self):
         """Return the path to the spec file"""
@@ -176,23 +175,17 @@ class Spec(object):
         return set(self.spec.sourceHeader['requires'])
 
     def source_package_path(self):
-        """Return the path of the source package which building this
-           spec will produce"""
-        hdr = self.spec.sourceHeader
-        hardcoded_macros = {
-            'NAME': hdr['name'],
-            'VERSION': hdr['version'],
-            'RELEASE': hdr['release'],
-            'ARCH': 'src'
-        }
-
-        with rpm_macros(self.macros, hardcoded_macros):
-            # There doesn't seem to be a macro for the name of the source
-            # rpm, but the name appears to be the same as the rpm name
-            # format. Unfortunately expanding that macro gives us a leading
-            # 'src' that we don't want, so we strip that off
-            srpmname = os.path.basename(rpm.expandMacro(self.srpmfilenamepat))
-            return rpm.expandMacro(os.path.join('%_srcrpmdir', srpmname))
+        """
+        Return the path of the source package which building this spec
+        will produce
+        """
+        # There doesn't seem to be a macro for the name of the source rpm
+        # but we can construct one using the 'NVR' RPM tag which returns the
+        # package's name-version-release string.  Naming is not critically
+        # important as these source RPMs are only used internally - mock
+        # will write a new source RPM along with the binary RPMS.
+        srpmname = self.spec.sourceHeader['nvr'] + ".src.rpm"
+        return rpm.expandMacro(os.path.join('%_srcrpmdir', srpmname))
 
     def binary_package_paths(self):
         """Return a list of binary packages built by this spec"""

--- a/planex/spec.py
+++ b/planex/spec.py
@@ -101,8 +101,6 @@ class Spec(object):
                         "spec file name '%s' does not match package name '%s'"
                         % (path, self.name()))
 
-            self.rpmfilenamepat = rpm.expandMacro('%_build_name_fmt')
-
     def specpath(self):
         """Return the path to the spec file"""
         return self.path
@@ -194,14 +192,14 @@ class Spec(object):
                will be built from hdr"""
 
             hardcoded_macros = {
-                'NAME': hdr['name'],
-                'VERSION': hdr['version'],
-                'RELEASE': hdr['release'],
-                'ARCH': hdr['arch']
+                'name': hdr['name'],
+                'version': hdr['version'],
+                'release': hdr['release'],
+                'arch': hdr['arch']
             }
 
             with rpm_macros(self.macros, hardcoded_macros):
-                rpmname = rpm.expandMacro(self.rpmfilenamepat)
+                rpmname = hdr.sprintf(rpm.expandMacro("%{_build_name_fmt}"))
                 return rpm.expandMacro(os.path.join('%_rpmdir', rpmname))
 
         return [rpm_name_from_header(pkg.header) for pkg in self.spec.packages]


### PR DESCRIPTION
* Extend rpm_macros() context manager to take multiple dicts, removing the need to use OrderedDict.
* Construct SRPM path directly
* Clean up confusion between RPM macros and tags in binary_package_paths()
* Factor out the extraction of NEVRA tag values