### PR TITLE
Consolidate Spec's various source getter methods

### DIFF
--- a/planex/cmd/depend.py
+++ b/planex/cmd/depend.py
@@ -39,9 +39,9 @@ def build_srpm_from_spec(spec, lnk=None):
     """
     srpmpath = spec.source_package_path()
     print('%s: %s' % (srpmpath, spec.specpath()))
-    for (url, path) in zip(spec.source_urls(), spec.source_paths()):
-        source = urlparse.urlparse(url)
-        if source.scheme in ["http", "https", "file", "ftp"]:
+    for (path, source) in spec.sources():
+        url = urlparse.urlparse(source)
+        if url.scheme in ["http", "https", "file", "ftp"]:
             # Source was downloaded to _build/SOURCES
             print('%s: %s' % (srpmpath, path))
         elif lnk and (lnk.sources is not None or lnk.has_patches):
@@ -56,9 +56,9 @@ def download_rpm_sources(spec):
     """
     Generate rules to download sources
     """
-    for (url, path) in zip(spec.source_urls(), spec.source_paths()):
-        source = urlparse.urlparse(url)
-        if source.scheme in ["http", "https", "file", "ftp"]:
+    for (path, source) in spec.sources():
+        url = urlparse.urlparse(source)
+        if url.scheme in ["http", "https", "file", "ftp"]:
             # Source can be fetched by fetch
             print('%s: %s' % (path, spec.specpath()))
 

--- a/planex/cmd/fetch.py
+++ b/planex/cmd/fetch.py
@@ -138,18 +138,6 @@ def check_supported_url(url):
                  (sys.argv[0], url.scheme))
 
 
-def url_for_source(spec, source):
-    """
-    Find the URL from which source should be downloaded
-    """
-    source_basename = os.path.basename(source)
-    for path, url in spec.all_sources():
-        if os.path.basename(path) == source_basename:
-            return path, url
-
-    raise KeyError(source_basename)
-
-
 def parse_args_or_exit(argv=None):
     """
     Parse command line options
@@ -184,11 +172,12 @@ def fetch_sources(args):
                             defines=args.define)
 
     try:
-        sources = [url_for_source(spec, source) for source in args.sources]
+        sources = [spec.source(source) for source in args.sources]
     except KeyError as exn:
         sys.exit("%s: No source corresponding to %s" % (sys.argv[0], exn))
 
     for path, url in sources:
+        url = urlparse.urlparse(url)
         check_supported_url(url)
         if url.scheme in SUPPORTED_URL_SCHEMES:
             if url.scheme != "file" and args.mirror:

--- a/planex/cmd/manifest.py
+++ b/planex/cmd/manifest.py
@@ -99,7 +99,7 @@ def generate_manifest(spec, link=None, pin=None):
     """
 
     manifest = {'spec': {}}
-    source_urls = [url for url in spec.source_urls() if '://' in url]
+    source_urls = [url for (_, url) in spec.sources() if '://' in url]
 
     for i, url in enumerate(source_urls):
         # Sources taken from artifactory do not have SHA1

--- a/planex/cmd/pin.py
+++ b/planex/cmd/pin.py
@@ -42,7 +42,7 @@ def repository_of(spec_or_link):
     """Return the Repository of the provided Spec source url or Link url.
        None if spec_or_link is None"""
     if isinstance(spec_or_link, Spec):
-        return Repository(spec_or_link.source_urls()[0])
+        return Repository(spec_or_link.sources()[0][1])
     if isinstance(spec_or_link, Link):
         return Repository(spec_or_link.url)
     if spec_or_link is None:

--- a/planex/spec.py
+++ b/planex/spec.py
@@ -211,10 +211,9 @@ class Spec(object):
         patches.append(-1)
         return max(patches)
 
-    def all_sources(self):
+    def sources(self):
         """List all sources defined in the spec file"""
-        urls = [urlparse.urlparse(url) for url in self.source_urls()]
-        return zip(self.source_paths(), urls)
+        return zip(self.source_paths(), self.source_urls())
 
     def remote_sources(self):
         """List all sources with remote URLs defined in the spec file"""

--- a/planex/spec.py
+++ b/planex/spec.py
@@ -226,11 +226,6 @@ class Spec(object):
         """List all sources defined in the spec file"""
         return zip(self.source_paths(), self.source_urls())
 
-    def remote_sources(self):
-        """List all sources with remote URLs defined in the spec file"""
-        return [(path, url) for (path, url) in self.all_sources()
-                if url.netloc != '']
-
     def local_sources(self):
         """List all local sources defined in the spec file"""
         patch_urls = [urlparse.urlparse(url) for (url, _, sourcetype)

--- a/planex/spec.py
+++ b/planex/spec.py
@@ -190,6 +190,17 @@ class Spec(object):
         srpmname = self.spec.sourceHeader['nvr'] + ".src.rpm"
         return rpm.expandMacro(os.path.join('%_srcrpmdir', srpmname))
 
+    def source(self, target):
+        """
+        Find the URL from which source should be downloaded
+        """
+        target_basename = os.path.basename(target)
+        for path, url in self.sources():
+            if os.path.basename(path) == target_basename:
+                return path, url
+
+        raise KeyError(target_basename)
+
     def binary_package_paths(self):
         """Return a list of binary packages built by this spec"""
 

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -45,6 +45,20 @@ class RpmTests(unittest.TestCase):
             self.spec.provides(),
             ["ocaml-cohttp", "ocaml-cohttp-devel"])
 
+    def test_sources(self):
+        """Package source paths and URLs are correct"""
+        self.assertItemsEqual(
+            self.spec.sources(),
+            [("./SOURCES/ocaml-cohttp/ocaml-cohttp-0.9.8.tar.gz",
+              "https://github.com/mirage/ocaml-cohttp/archive/"
+              "ocaml-cohttp-0.9.8/ocaml-cohttp-0.9.8.tar.gz"),
+             ("./SOURCES/ocaml-cohttp/ocaml-cohttp-init",
+              "ocaml-cohttp-init"),
+             ("./SOURCES/ocaml-cohttp/ocaml-cohttp-service",
+              "ocaml-cohttp-service"),
+             ("./SOURCES/ocaml-cohttp/cohttp0.patch", "cohttp0.patch"),
+             ("./SOURCES/ocaml-cohttp/cohttp1.patch", "cohttp1.patch")])
+
     def test_source_urls(self):
         """Package source URLs are correct"""
         self.assertItemsEqual(

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -59,27 +59,6 @@ class RpmTests(unittest.TestCase):
              ("./SOURCES/ocaml-cohttp/cohttp0.patch", "cohttp0.patch"),
              ("./SOURCES/ocaml-cohttp/cohttp1.patch", "cohttp1.patch")])
 
-    def test_source_urls(self):
-        """Package source URLs are correct"""
-        self.assertItemsEqual(
-            self.spec.source_urls(),
-            ["https://github.com/mirage/ocaml-cohttp/archive/"
-             "ocaml-cohttp-0.9.8/ocaml-cohttp-0.9.8.tar.gz",
-             "ocaml-cohttp-init",
-             "ocaml-cohttp-service",
-             "cohttp0.patch",
-             "cohttp1.patch"])
-
-    def test_source_paths(self):
-        """Package source paths on disk are correct"""
-        self.assertItemsEqual(
-            self.spec.source_paths(),
-            ["./SOURCES/ocaml-cohttp/ocaml-cohttp-0.9.8.tar.gz",
-             "./SOURCES/ocaml-cohttp/ocaml-cohttp-init",
-             "./SOURCES/ocaml-cohttp/ocaml-cohttp-service",
-             "./SOURCES/ocaml-cohttp/cohttp0.patch",
-             "./SOURCES/ocaml-cohttp/cohttp1.patch"])
-
     def test_source(self):
         """URLs for individual sources are correct"""
         self.assertEqual(

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -80,6 +80,25 @@ class RpmTests(unittest.TestCase):
              "./SOURCES/ocaml-cohttp/cohttp0.patch",
              "./SOURCES/ocaml-cohttp/cohttp1.patch"])
 
+    def test_source(self):
+        """URLs for individual sources are correct"""
+        self.assertEqual(
+            self.spec.source("path/to/ocaml-cohttp-0.9.8.tar.gz"),
+            ("./SOURCES/ocaml-cohttp/ocaml-cohttp-0.9.8.tar.gz",
+             "https://github.com/mirage/ocaml-cohttp/archive/"
+             "ocaml-cohttp-0.9.8/ocaml-cohttp-0.9.8.tar.gz"))
+        self.assertEqual(
+            self.spec.source("ocaml-cohttp-init"),
+            ("./SOURCES/ocaml-cohttp/ocaml-cohttp-init", "ocaml-cohttp-init"))
+        self.assertEqual(
+            self.spec.source("somewhere/cohttp0.patch"),
+            ("./SOURCES/ocaml-cohttp/cohttp0.patch", "cohttp0.patch"))
+
+    def test_source_nonexistent(self):
+        """Nonexistent sources are handled correctly"""
+        with self.assertRaises(KeyError):
+            self.spec.source("nonexistent")
+
     def test_requires(self):
         """Package runtime requirements are correct"""
         self.assertEqual(


### PR DESCRIPTION
This pull request consolidates most sources getters into sources() and adds a source() convenience method to fetch the source corresponding to a downloaded file name.

local_sources() and local_patches() remain but will be dealt with in the next pull request.