### PR TITLE
patchqueue: Apply patchqueues to specs with %autopatch directives

### DIFF
--- a/planex/patchqueue.py
+++ b/planex/patchqueue.py
@@ -110,7 +110,8 @@ def expand_patchqueue(spec, series):
     patchnum = spec.highest_patch()
     found_autosetup = False
     for line in spec.spectext:
-        if line.startswith("%autosetup") and "-p1" in line:
+        if "-p1 in line" and (line.startswith("%autosetup") or
+                              line.startswith("%autopatch")):
             found_autosetup = True
             break
     if not found_autosetup:


### PR DESCRIPTION
%autosetup is actually a wrapper around %setup and %autopatch, so
%autopatch should also be able to apply patchqueues.

Signed-off-by: Euan Harris <euan.harris@citrix.com>