### PR TITLE
makesrpm: Fetch sources as well as patches from 'Patch' tarballs

### DIFF
--- a/planex/cmd/makesrpm.py
+++ b/planex/cmd/makesrpm.py
@@ -169,8 +169,9 @@ def extract_v2_patches(tmpdir, spec, tmp_specfile, link, patchdata):
                         if os.path.basename(patch) == tarname][0]
             with Tarball(patchset) as tarball:
                 extract_tarball_patches(
-                    tmpdir, spec, tarball, None,
-                    link.patch_sources[patchsource]['patches'])
+                    tmpdir, spec, tarball,
+                    link.patch_sources[patchsource].get('sources'),
+                    link.patch_sources[patchsource].get('patches'))
 
     if PATCHQUEUES in patchdata:
         patchqueues = patchdata[PATCHQUEUES]


### PR DESCRIPTION
A spec file can list source files (e.g. source0: ...) and patch
files (e.g. patch0: ...).   If a source or patch has a URL, Planex
can fetch it and pack it into the SRPM;  if the spec only lists
a plain file name, then the file must exist in a subdirectory of
the spec file repository or there must be a link file which tells planex
where to fetch an archive which contains the file.

In the original link format, a single tarball holds the 'extra'
patches and sources, such as service files, along with a single
patchqueue:

```
{
    "URL": "https://...#/pkg.patches.tar",
    "patches": "SOURCES",
    "sources": "PATCHES",
    "patchqueue": "PATCHQUEUE"
}

```
"patches", "sources" and "patchqueue" are optional fields - if they
are present they are the subdirectories in which the various types
of files are stored.   Different types of files can be stored in the
same subdirectory;  the top level directory is represented by the empty
string "".   Makesrpm searches for unknown source files in the "sources"
directory and unknown patches in the "patches" directory; the patchqueue
is injected into the spec separately.    Patches and sources are different
file types in RPM, so they are searched for separately.

The V2 format has separate top-level entries for sources (currently unused),
patch archives and patchqueues:

```
{
    "SchemaVersion": "2",
    "Source0": {
        "URL": "https://...#/pkg.patches.tar"
    },
    "Patch0": {
        "URL": "https://...#/pkg.patches.tar",
        "patches": "SOURCES"
    }
    "PatchQueue0": {
        "URL": "https://...#/pkg.patches.tar",
        "patchqueue": "PATCHQUEUE"
    }
}
```

As it is currently implemented, makesrpm only searches for patch files
in the "patch" entry - the "sources" prefix from V1 is not supported.
This means that there is no way to include extra sources in the patch
archive.   This change add support for a "sources" prefix in a "patch"
entry, restoring the behaviour of the "sources" entry from V1.

Signed-off-by: Euan Harris <euan.harris@citrix.com>