### PR TITLE
link: Anchor parsing regexes to start and end of keys

### DIFF
--- a/planex/link.py
+++ b/planex/link.py
@@ -56,7 +56,7 @@ class Link(object):
         if self.schema_version < 2:
             return self.link.get('sources', None)
 
-        patch_matcher = re.compile(r'source\d*', re.IGNORECASE)
+        patch_matcher = re.compile(r'^source\d*$', re.IGNORECASE)
         return {k: v for k, v
                 in self.link.iteritems()
                 if patch_matcher.match(k)}
@@ -83,8 +83,7 @@ class Link(object):
         if self.schema_version < 2:
             raise UnsupportedProperty('patch_sources requries at least'
                                       'schema version 2')
-
-        patch_matcher = re.compile(r'patch\d*', re.IGNORECASE)
+        patch_matcher = re.compile(r'^patch\d*$', re.IGNORECASE)
         return {k: v for k, v
                 in self.link.iteritems()
                 if patch_matcher.match(k)}
@@ -96,7 +95,7 @@ class Link(object):
             raise UnsupportedProperty('patchqueue_sources requries at least'
                                       'schema version 2')
 
-        patch_matcher = re.compile(r'patchqueue\d*', re.IGNORECASE)
+        patch_matcher = re.compile(r'^patchqueue\d*$', re.IGNORECASE)
         return {k: v for k, v
                 in self.link.iteritems()
                 if patch_matcher.match(k)}

--- a/planex/spec.py
+++ b/planex/spec.py
@@ -269,7 +269,7 @@ def _parse_name(name):
 
     Raises KeyError if [name] cannot be parsed
     """
-    matcher = re.compile(r"\A[a-zA-Z]+(\d*)\Z")
+    matcher = re.compile(r"^[a-zA-Z]+(\d*)$")
     match = matcher.match(name)
 
     if match is None:

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -82,6 +82,7 @@ class TestLink(unittest.TestCase):
         link = planex.link.Link('test_v2.lnk')
         sources = link.patch_sources
         self.assertIn('Patch0', sources)
+        self.assertNotIn('PatchQueue0', sources)
 
     @mock.patch('planex.link.open', mock.mock_open(read_data=v2_link))
     def test_patchqueue_sources_v2(self):


### PR DESCRIPTION
The change of the 'patch' name parsing regex to accept zero or more digits
(patch\d*) causes it also to match 'patchqueue'.

Signed-off-by: Euan Harris <euan.harris@citrix.com>