### PR TITLE
Rewrite all sources and patches in the spec file

### DIFF
--- a/planex/cmd/makesrpm.py
+++ b/planex/cmd/makesrpm.py
@@ -137,7 +137,7 @@ def populate_working_directory(tmpdir, spec):
     manifests = {}
 
     with open(newspec, "w") as out:
-        out.writelines(spec.expand_patchqueues())
+        out.writelines(spec.rewrite_spec())
 
     if manifests:
         add_manifest_entry(manifests, newspec)

--- a/planex/patchqueue.py
+++ b/planex/patchqueue.py
@@ -52,14 +52,6 @@ class Patchqueue(object):
         for patch in self.series():
             self.extract(patch, destdir)
 
-    def add_to_spec(self, spec, outfile):
-        """
-        Insert patches into spec, writing output to outfile
-        """
-        with open(outfile, "w") as specfile_out:
-            expanded = expand_patchqueue(spec, self.series())
-            specfile_out.writelines(expanded)
-
 
 def parse_patchseries(series, guard=None):
     """

--- a/planex/patchqueue.py
+++ b/planex/patchqueue.py
@@ -106,14 +106,12 @@ def expand_patchqueue(spec, series):
     """
     Create a list of patches from a patchqueue and update the spec file
     """
+    # check specfile integrity for patchqueues
+    if not any(line.startswith(r"%autosetup") or
+               line.startswith(r"%autopatch")
+               for line in spec.spectext):
+        raise SpecMissingAutosetup(spec.path)
+
     patches = list(series)
     patchnum = spec.highest_patch()
-    found_autosetup = False
-    for line in spec.spectext:
-        if "-p1 in line" and (line.startswith("%autosetup") or
-                              line.startswith("%autopatch")):
-            found_autosetup = True
-            break
-    if not found_autosetup:
-        raise SpecMissingAutosetup()
     return rewrite_spec(spec, patches, patchnum)

--- a/planex/patchqueue.py
+++ b/planex/patchqueue.py
@@ -85,24 +85,7 @@ def parse_patchseries(series, guard=None):
         yield match.group(1)
 
 
-def rewrite_spec(spec, patches, patchnum):
-    """
-    Expand a patchqueue as a sequence of patches in a spec file
-    """
-    done = False
-    for line in spec.spectext:
-        yield line
-        upper_line = line.upper()
-        if not done and (
-                (upper_line.startswith('SOURCE') and patchnum == -1) or
-                (upper_line.startswith('PATCH%s' % patchnum))):
-            for patch in patches:
-                patchnum += 1
-                yield "Patch%d: %s\n" % (patchnum, patch)
-            done = True
-
-
-def expand_patchqueue(spec, series):
+def check_spec_supports_patchqueues(spec):
     """
     Create a list of patches from a patchqueue and update the spec file
     """
@@ -111,7 +94,3 @@ def expand_patchqueue(spec, series):
                line.startswith(r"%autopatch")
                for line in spec.spectext):
         raise SpecMissingAutosetup(spec.path)
-
-    patches = list(series)
-    patchnum = spec.highest_patch()
-    return rewrite_spec(spec, patches, patchnum)

--- a/planex/spec.py
+++ b/planex/spec.py
@@ -373,6 +373,12 @@ class Spec(object):
         Rewrite the sources and patches in the spec file, also inserting the
         names of all patchqueue patches into it
         """
+
+        # If there is nothing to rewrite, don't rewrite!
+        if not (self._sources or self._patches or self._patchqueues):
+            return self.spectext
+
+        # If there are patches, make sure we use autosetup or autopatch
         if self._patches or self._patchqueues:
             planex.patchqueue.check_spec_supports_patchqueues(self)
 

--- a/planex/spec.py
+++ b/planex/spec.py
@@ -401,7 +401,7 @@ class Spec(object):
         # we are sorting patches and sources to avoid tripping on weird
         # centos bug like https://bugzilla.redhat.com/show_bug.cgi?id=1359084
         def sorted_by_key(dictionary):
-            """Return an iterable of key, value tuples orderedy by key"""
+            """Return an iterable of key, value tuples ordered by key"""
             return sorted(dictionary, key=lambda kv: kv[0])
 
         sources = (

--- a/planex/spec.py
+++ b/planex/spec.py
@@ -320,6 +320,7 @@ def load(specpath, link=None, check_package_name=True, defines=None):
     return spec
 
 
+# pylint: disable=too-many-instance-attributes
 class Spec(object):
     """Represents an RPM spec file"""
 

--- a/planex/spec.py
+++ b/planex/spec.py
@@ -11,6 +11,8 @@ import shutil
 import sys
 import tempfile
 
+from itertools import chain
+
 import rpm
 
 from planex.tarball import Tarball
@@ -365,18 +367,65 @@ class Spec(object):
         """Return the path to the spec file"""
         return self.path
 
-    def expand_patchqueues(self):
+    def rewrite_spec(self):
         """
-        Insert the names of all patchqueue patches into the spec file
+        Rewrite the sources and patches in the spec file, also inserting the
+        names of all patchqueue patches into it
         """
-        patchqueues = [self._patchqueues[key] for key
-                       in sorted(self._patchqueues.keys())]
-        if not patchqueues:
-            return self.spectext
+        if self._patches or self._patchqueues:
+            planex.patchqueue.check_spec_supports_patchqueues(self)
 
+        def is_source_or_patch_line(line):
+            """True if the line does start with Source or Patch"""
+            source = re.compile("^source", re.IGNORECASE)
+            patch = re.compile("^patch", re.IGNORECASE)
+            return bool(patch.match(line) or source.match(line))
+
+        def first_index(iterable, predicate):
+            """
+            Returns the index of first value in the iterable
+            for which predicate(value) is true.
+            """
+            return next(i for i, v in enumerate(iterable) if predicate(v))
+
+        split_at = first_index(self.spectext, is_source_or_patch_line)
+
+        newspec_header = self.spectext[:split_at]
+        newspec_filtered_body = (
+            line for line
+            in self.spectext[split_at+1:]
+            if not is_source_or_patch_line(line)
+        )
+
+        # we are sorting patches and sources to avoid tripping on weird
+        # centos bug like https://bugzilla.redhat.com/show_bug.cgi?id=1359084
+        def sorted_by_key(dictionary):
+            """Return an iterable of key, value tuples orderedy by key"""
+            return sorted(dictionary, key=lambda kv: kv[0])
+
+        sources = (
+            "Source{}: {}".format(index, blob.url)
+            for index, blob in sorted_by_key(self._sources.items())
+        )
+        patches = (
+            "Patch{}: {}".format(index, blob.url)
+            for index, blob in sorted_by_key(self._patches.items())
+        )
+
+        patchqueues = (self._patchqueues[key] for key
+                       in sorted(self._patchqueues.keys()))
         series = sum([pq.series() for pq in patchqueues], [])
-        spec = planex.patchqueue.expand_patchqueue(self, series)
-        return "".join(list(spec))
+        base_index = 1 + self.highest_patch()
+        further_patches = (
+            "Patch{}: {}".format(base_index + index, patch)
+            for index, patch in enumerate(series)
+        )
+
+        newspec = chain(
+            newspec_header,
+            sources, patches, further_patches,
+            newspec_filtered_body)
+        return "\n".join(newspec)
 
     def provides(self):
         """Return a list of package names provided by this spec"""
@@ -524,7 +573,6 @@ class Spec(object):
 
     def highest_patch(self):
         """Return the number the highest numbered patch or -1"""
-        patches = [num for (_, num, sourcetype) in self.spec.sources
-                   if sourcetype == 2]
-        patches.append(-1)
-        return max(patches)
+        patches_indices = self._patches.keys()
+        fallback = (-1,)
+        return max(chain(patches_indices, fallback))

--- a/tests/data/empty.spec
+++ b/tests/data/empty.spec
@@ -1,0 +1,19 @@
+%global debug_package %{nil}
+
+Name:           empty
+Version:        1.0.0
+Release:        1%{?dist}
+Summary:        An Empty Spec File
+License:        LGPL
+Group:          Development/Libraries
+URL:            https://github.com/xenserver/planex
+
+Requires:       git
+
+%description
+An Empty Spec File
+
+%changelog
+* Thu Mar 29 2018 Marcello Seri <marcello.seri@citrix.com> - 1.0.0-1
+- Initial package
+

--- a/tests/test_patchqueue.py
+++ b/tests/test_patchqueue.py
@@ -42,26 +42,42 @@ class BasicTests(unittest.TestCase):
         """Patches are inserted into rewritten spec file"""
         spec = Spec("tests/data/manifest/branding-xenserver.spec",
                     check_package_name=False)
-        patches = ["first.patch", "second.patch", "third.patch"]
-        rewritten = planex.patchqueue.expand_patchqueue(spec, patches)
+        spec.add_patch(0, "first.patch", "dummy")
+        spec.add_patch(1, "second.patch", "dummy")
+        spec.add_patch(2, "third.patch", "dummy")
+
+        rewritten = spec.rewrite_spec()
         self.assertIn("Patch0: first.patch\n", rewritten)
         self.assertIn("Patch1: second.patch\n", rewritten)
         self.assertIn("Patch2: third.patch\n", rewritten)
+
+    def test_overridden_patch_in_spec(self):
+        """Patches with the same index override each other"""
+        spec = Spec("tests/data/manifest/branding-xenserver.spec",
+                    check_package_name=False)
+        spec.add_patch(0, "first.patch", "dummy")
+        spec.add_patch(1, "second.patch", "dummy")
+        spec.add_patch(0, "third.patch", "dummy")
+
+        rewritten = spec.rewrite_spec()
+        self.assertNotIn("Patch0: first.patch\n", rewritten)
+        self.assertIn("Patch1: second.patch\n", rewritten)
+        self.assertIn("Patch0: third.patch\n", rewritten)
 
     def test_autosetup_present(self):
         """Patchqueue application succeeds if %autosetup is present"""
         spec = Spec("tests/data/manifest/branding-xenserver.spec",
                     check_package_name=False)
-        patches = ["first.patch"]
-        rewritten = planex.patchqueue.expand_patchqueue(spec, patches)
+        spec.add_patch(0, "first.patch", "dummy")
+        rewritten = spec.rewrite_spec()
         self.assertIn("Patch0: first.patch\n", rewritten)
 
     def test_autosetup_missing(self):
         """Patchqueue application fails if %autosetup is not present"""
         spec = Spec("tests/data/ocaml-uri.spec", check_package_name=False)
-        patches = ["first.patch"]
+        spec.add_patch(0, "first.patch", "dummy")
         with self.assertRaises(planex.patchqueue.SpecMissingAutosetup):
-            planex.patchqueue.expand_patchqueue(spec, patches)
+            spec.rewrite_spec()
 
 
 # Mercurial's guard logic is documented in:

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -200,3 +200,12 @@ class RpmSourceNameParsingTest(unittest.TestCase):
             [Blob(spec, "tests/data/test-git.tar.gz",
                   "tests/data/ocaml-cstruct.lnk")]
         )
+
+    def test_spec_not_rewritten(self):
+        """Spec files with no patches or sources should not be rewritten"""
+        spec = planex.spec.load("tests/data/empty.spec", link=None,
+                                defines=RPM_DEFINES)
+        self.assertEqual(
+            spec.spectext,
+            spec.rewrite_spec()
+        )


### PR DESCRIPTION
When rewriting the specs, we delete any Source and Patch entry from the spec file
and we inject:

- first the list of computed sources (link, spec)
- then the list of computed patches (link, spec)
- finally the exploded patchqueues (link).

This should solve #510 and #511 