### PR TITLE
Enable check for autosetup/autopatch only for patchqueues 

### DIFF
--- a/planex/spec.py
+++ b/planex/spec.py
@@ -382,7 +382,7 @@ class Spec(object):
             return self.spectext
 
         # If there are patches, make sure we use autosetup or autopatch
-        if self._patches or self._patchqueues:
+        if self._patchqueues:
             planex.patchqueue.check_spec_supports_patchqueues(self)
 
         def is_source_or_patch_line(line):

--- a/tests/test_patchqueue.py
+++ b/tests/test_patchqueue.py
@@ -64,20 +64,20 @@ class BasicTests(unittest.TestCase):
         self.assertIn("Patch1: second.patch\n", rewritten)
         self.assertIn("Patch0: third.patch\n", rewritten)
 
-    def test_autosetup_present(self):
-        """Patchqueue application succeeds if %autosetup is present"""
-        spec = Spec("tests/data/manifest/branding-xenserver.spec",
-                    check_package_name=False)
-        spec.add_patch(0, "first.patch", "dummy")
-        rewritten = spec.rewrite_spec()
-        self.assertIn("Patch0: first.patch\n", rewritten)
+    # def test_autosetup_present(self):
+    #     """Patchqueue application succeeds if %autosetup is present"""
+    #     spec = Spec("tests/data/manifest/branding-xenserver.spec",
+    #                 check_package_name=False)
+    #     spec.add_patch(0, "first.patch", "dummy")
+    #     rewritten = spec.rewrite_spec()
+    #     self.assertIn("Patch0: first.patch\n", rewritten)
 
-    def test_autosetup_missing(self):
-        """Patchqueue application fails if %autosetup is not present"""
-        spec = Spec("tests/data/ocaml-uri.spec", check_package_name=False)
-        spec.add_patch(0, "first.patch", "dummy")
-        with self.assertRaises(planex.patchqueue.SpecMissingAutosetup):
-            spec.rewrite_spec()
+    # def test_autosetup_missing(self):
+    #     """Patchqueue application fails if %autosetup is not present"""
+    #     spec = Spec("tests/data/ocaml-uri.spec", check_package_name=False)
+    #     spec.add_patch(0, "first.patch", "dummy")
+    #     with self.assertRaises(planex.patchqueue.SpecMissingAutosetup):
+    #         spec.rewrite_spec()
 
 
 # Mercurial's guard logic is documented in:


### PR DESCRIPTION
This is temporary, until we extens schemaVersion3 to add a ignore-autosetup field (see issue #521)