### PR TITLE
Refactor schemaVersion to distinguish between 2 and 3, and drop support for 1

### DIFF
--- a/planex/spec.py
+++ b/planex/spec.py
@@ -299,15 +299,7 @@ def load(specpath, link=None, check_package_name=True, defines=None):
     spec = Spec(specpath, check_package_name=check_package_name,
                 defines=defines)
     if link:
-        if link.schema_version == 1:
-            if link.sources:
-                spec.add_archive(0, link.url, link.path, link.sources)
-            if link.patches:
-                spec.add_archive(1, link.url, link.path, link.patches)
-            if link.patchqueue:
-                spec.add_patchqueue(0, link.url, link.path,
-                                    link.patchqueue)
-        elif link.schema_version == 2:
+        if link.schema_version == 2:
             for name, value in link.patch_sources.items():
                 idx = _parse_name(name)
                 spec.add_archive(name, value["URL"], link.path,

--- a/planex/spec.py
+++ b/planex/spec.py
@@ -286,6 +286,11 @@ def _parse_name(name):
     return int(idx)
 
 
+class InvalidSchemaVersion(KeyError):
+    """Error raised if the schemaVersion field in the pins is not supported"""
+    pass
+
+
 def load(specpath, link=None, check_package_name=True, defines=None):
     """
     Load the spec file at specpath and apply link if provided.
@@ -302,7 +307,16 @@ def load(specpath, link=None, check_package_name=True, defines=None):
             if link.patchqueue:
                 spec.add_patchqueue(0, link.url, link.path,
                                     link.patchqueue)
-        elif link.schema_version >= 2:
+        elif link.schema_version == 2:
+            for name, value in link.patch_sources.items():
+                idx = _parse_name(name)
+                spec.add_archive(name, value["URL"], link.path,
+                                 value["patches"])
+            for name, value in link.patchqueue_sources.items():
+                idx = _parse_name(name)
+                spec.add_patchqueue(idx, value["URL"], link.path,
+                                    value["patchqueue"])
+        elif link.schema_version == 3:
             for name, value in link.sources.items():
                 idx = _parse_name(name)
                 if value["URL"].startswith("ssh://"):

--- a/tests/data/ocaml-cohttp.lnk
+++ b/tests/data/ocaml-cohttp.lnk
@@ -1,5 +1,5 @@
 {
-    "SchemaVersion": "2",
+    "SchemaVersion": "3",
     "Source1":
     {
         "URL": "tests/data/ocaml-cohttp-init"

--- a/tests/data/ocaml-cstruct.lnk
+++ b/tests/data/ocaml-cstruct.lnk
@@ -1,5 +1,5 @@
 {
-    "SchemaVersion": "2",
+    "SchemaVersion": "3",
     "Source":
     {
         "URL": "tests/data/test-git.tar.gz"

--- a/tests/specs/SPECS/PQ.lnk
+++ b/tests/specs/SPECS/PQ.lnk
@@ -1,4 +1,7 @@
 {
-	"URL": "https://github.com/xenserver/nsource/archive/PQ.tar.gz",
-	"patchqueue": "master"
+	"SchemaVersion": "3",
+	"PatchQueue0": {
+		"URL": "https://github.com/xenserver/nsource/archive/PQ.tar.gz",
+		"patchqueue": "master"
+	}
 }

--- a/tests/specs/SPECS/RP.lnk
+++ b/tests/specs/SPECS/RP.lnk
@@ -1,4 +1,7 @@
 {
-	"URL": "https://github.com/xenserver/nsource/archive/RP.tar.gz",
-	"patches": "SOURCES"
+	"SchemaVersion": "3",
+	"Patch0": {
+		"URL": "https://github.com/xenserver/nsource/archive/RP.tar.gz",
+		"patches": "SOURCES"
+	}
 }


### PR DESCRIPTION
This should solve #503 and #515.

~~This PR also introduces a way to delete a source, a patchqueue or a patch by providing an empty record in the link/pin file. I have created #529 to track that as I recall that issue being discussed at a certain point. I am happy to remove the relevant commits if we decide that this is not necessary.~~

EDIT: Removed, it will be part of a separate PR if we decide to stack pins over links