### PR TITLE
Link cleanup

### DIFF
--- a/planex/cmd/clone.py
+++ b/planex/cmd/clone.py
@@ -10,7 +10,7 @@ from os.path import basename, dirname, join, relpath
 import subprocess
 
 import git
-from planex.link import Link
+# from planex.link import Link
 import planex.util as util
 
 
@@ -116,25 +116,29 @@ def main(argv=None):
     """
     Entry point
     """
-    args = parse_args_or_exit(argv)
+    _args = parse_args_or_exit(argv)
 
-    for pinpath in args.pins:
-        pin = Link(pinpath)
+    # for pinpath in args.pins:
+    #     pin = Link(pinpath)
 
-        if args.jenkins:
-            print('echo "Cloning %s"' % pin.url)
-            clone_jenkins(pin.url, args.repos, pin.commitish, args.credentials)
+    #     if args.jenkins:
+    #         print('echo "Cloning %s"' % pin.url)
+    #         clone_jenkins(pin.url, args.repos,
+    #                       pin.commitish, args.credentials)
 
-        else:
-            try:
-                print("Cloning %s" % pin.url)
-                util.makedirs(args.repos)
-                pq_repo = clone(pin.url, args.repos, pin.commitish)
+    #     else:
+    #         try:
+    #             print("Cloning %s" % pin.url)
+    #             util.makedirs(args.repos)
+    #             pq_repo = clone(pin.url, args.repos, pin.commitish)
 
-                if args.clone_base and pin.base:
-                    print("Cloning %s" % pin.base)
-                    base_repo = clone(pin.base, args.repos, pin.base_commitish)
-                    apply_patchqueue(base_repo, pq_repo, pin.patchqueue)
+    #             if args.clone_base and pin.base:
+    #                 print("Cloning %s" % pin.base)
+    #                 base_repo = clone(pin.base, args.repos,
+    #                                   pin.base_commitish)
+    #                 apply_patchqueue(base_repo, pq_repo, pin.patchqueue)
 
-            except git.GitCommandError as gce:
-                print(gce.stderr)
+    #         except git.GitCommandError as gce:
+    #             print(gce.stderr)
+
+    raise NotImplementedError

--- a/planex/cmd/manifest.py
+++ b/planex/cmd/manifest.py
@@ -111,22 +111,22 @@ def generate_manifest(spec, link=None, pin=None):
 
         manifest['spec']['source' + str(i)] = {'url': url, 'sha1': sha1}
 
-    if link is not None and link.url:
-        repo_ref = Repository(link.url)
-        sha1 = repo_ref.sha1
-        manifest['lnk'] = {'url': link.url, 'sha1': sha1}
+    # if link is not None and link.get("URL"):
+    #     repo_ref = Repository(link.get("URL"))
+    #     sha1 = repo_ref.sha1
+    #     manifest['lnk'] = {'url': link.get("URL"), 'sha1': sha1}
 
-    if pin is not None:
-        with open(pin) as pinfile:
-            pin_dict = json.load(pinfile)
-            url = pin_dict['URL']
-            # pylint: disable=broad-except
-            try:
-                repo_ref = Repository(url)
-                sha1 = repo_ref.sha1
-            except Exception:
-                sha1 = None
-            manifest['pin'] = {'url': url, 'sha1': sha1}
+    # if pin is not None:
+    #     with open(pin) as pinfile:
+    #         pin_dict = json.load(pinfile)
+    #         url = pin_dict['URL']
+    #         # pylint: disable=broad-except
+    #         try:
+    #             repo_ref = Repository(url)
+    #             sha1 = repo_ref.sha1
+    #         except Exception:
+    #             sha1 = None
+    #         manifest['pin'] = {'url': url, 'sha1': sha1}
 
     return manifest
 

--- a/planex/link.py
+++ b/planex/link.py
@@ -77,6 +77,18 @@ class Link(object):
                 if patch_matcher.match(k)}
 
     @property
+    def archives(self):
+        """Return the ordered set of patch source definitions"""
+        if self.schema_version == 2:
+            raise UnsupportedProperty(
+                "archiveX is not supported in SchemaVersion 2")
+
+        patch_matcher = re.compile(r'^archive\d*$', re.IGNORECASE)
+        return {k: v for k, v
+                in self.link.iteritems()
+                if patch_matcher.match(k)}
+
+    @property
     def patchqueue_sources(self):
         """Return the ordered set of patchqueue definitions"""
         patch_matcher = re.compile(r'^patchqueue\d*$', re.IGNORECASE)

--- a/planex/link.py
+++ b/planex/link.py
@@ -20,17 +20,18 @@ class Link(object):
         self.path = path
         with open(path) as fileh:
             self.link = json.load(fileh)
-
-    @property
-    def schema_version(self):
-        """Return the schema version of the link file"""
         schema_version = self.link.get('SchemaVersion', None)
         if schema_version is None:
             raise UnsupportedProperty("SchemaVersion field is not present")
         schema_version = int(schema_version)
         if schema_version == 1:
             raise UnsupportedProperty("SchemaVersion 1 is no longer supported")
-        return schema_version
+        self._schema_version = schema_version
+
+    @property
+    def schema_version(self):
+        """Return the schema version of the link file"""
+        return self._schema_version
 
     @property
     def ignore_autosetup(self):

--- a/planex/link.py
+++ b/planex/link.py
@@ -24,8 +24,13 @@ class Link(object):
     @property
     def schema_version(self):
         """Return the schema version of the link file"""
-        # Default to v1 if not present, for legacy lnks
-        return int(self.link.get('SchemaVersion', 1))
+        schema_version = self.link.get('SchemaVersion', None)
+        if schema_version is None:
+            raise UnsupportedProperty("SchemaVersion field is not present")
+        schema_version = int(schema_version)
+        if schema_version == 1:
+            raise UnsupportedProperty("SchemaVersion 1 is no longer supported")
+        return schema_version
 
     @property
     def ignore_autosetup(self):
@@ -52,45 +57,20 @@ class Link(object):
         return self.link.get('commitish', None)
 
     @property
-    def patchqueue(self):
-        """Return the path to the patchqueue inside the patchqueue tarball"""
-        if self.schema_version > 1:
-            raise UnsupportedProperty('patchqueue only supported on v1')
-        return self.link.get('patchqueue', None)
-
-    @property
     def sources(self):
         """Return the path to extra sources inside the patchqueue tarball"""
-        if self.schema_version < 2:
-            return self.link.get('sources', None)
-
         patch_matcher = re.compile(r'^source\d*$', re.IGNORECASE)
         return {k: v for k, v
                 in self.link.iteritems()
                 if patch_matcher.match(k)}
 
     @property
-    def patches(self):
-        """Return the path to extra patches inside the patchqueue tarball"""
-        return self.link.get('patches', None)
-
-    @property
-    def base_commitish(self):
-        """Return the commitish from which to fetch the patchqueue"""
-        return self.link.get('base_commitish', None)
-
-    @property
-    def base(self):
-        """Return the base repository on top of which to apply the
-           patchqueue"""
-        return self.link.get('base', None)
-
-    @property
     def patch_sources(self):
         """Return the ordered set of patch source definitions"""
-        if self.schema_version < 2:
-            raise UnsupportedProperty('patch_sources requries at least'
-                                      'schema version 2')
+        if self.schema_version > 2:
+            raise UnsupportedProperty(
+                "patchX is supported only in SchemaVersion 2")
+
         patch_matcher = re.compile(r'^patch\d*$', re.IGNORECASE)
         return {k: v for k, v
                 in self.link.iteritems()
@@ -99,10 +79,6 @@ class Link(object):
     @property
     def patchqueue_sources(self):
         """Return the ordered set of patchqueue definitions"""
-        if self.schema_version < 2:
-            raise UnsupportedProperty('patchqueue_sources requries at least'
-                                      'schema version 2')
-
         patch_matcher = re.compile(r'^patchqueue\d*$', re.IGNORECASE)
         return {k: v for k, v
                 in self.link.iteritems()
@@ -111,6 +87,4 @@ class Link(object):
     @property
     def has_patches(self):
         """ Test if the lnk defines patches """
-        return ((self.schema_version == 1 and self.patches is not None) or
-                (self.schema_version >= 2 and
-                 (self.patch_sources or self.patchqueue_sources)))
+        return self.patch_sources or self.patchqueue_sources

--- a/planex/link.py
+++ b/planex/link.py
@@ -47,17 +47,6 @@ class Link(object):
         return self.path
 
     @property
-    def url(self):
-        """Return the URL from which to fetch the patchqueue tarball"""
-        return self.link.get('URL', None)
-
-    @property
-    def commitish(self):
-        """Return the Git commitish to use when constructing patchqueue.
-           Used mainly for pinning."""
-        return self.link.get('commitish', None)
-
-    @property
     def sources(self):
         """Return the path to extra sources inside the patchqueue tarball"""
         patch_matcher = re.compile(r'^source\d*$', re.IGNORECASE)

--- a/planex/spec.py
+++ b/planex/spec.py
@@ -395,13 +395,15 @@ def update_with_schema_version_2(spec, link):
     """Update spec with a schemaVersion 2 link"""
     for name, value in link.patch_sources.items():
         idx = _parse_name(name)
-        spec.add_archive(name, value["URL"], link.path,
-                         value["patches"])
+        spec.add_archive(name,
+                         Archive(spec, value["URL"], link.path,
+                                 value["patches"]))
 
     for name, value in link.patchqueue_sources.items():
         idx = _parse_name(name)
-        spec.add_patchqueue(idx, value["URL"], link.path,
-                            value["patchqueue"])
+        spec.add_patchqueue(idx,
+                            Patchqueue(spec, value["URL"], link.path,
+                                       value["patchqueue"]))
 
 
 def update_with_schema_version_3(spec, link):

--- a/planex/spec.py
+++ b/planex/spec.py
@@ -360,15 +360,15 @@ def update_with_schema_version_3(spec, link):
         else:
             spec.add_source(idx, value["URL"], link.path)
 
-    for name, value in link.patch_sources.items():
+    for name, value in link.archives.items():
         idx = _parse_name(name)
         spec.add_archive(idx, value["URL"], link.path,
-                         value["patches"])
+                         value["prefix"])
 
     for name, value in link.patchqueue_sources.items():
         idx = _parse_name(name)
         spec.add_patchqueue(idx, value["URL"], link.path,
-                            value["patchqueue"])
+                            value["prefix"])
 
 
 def load(specpath, link=None, check_package_name=True, defines=None):

--- a/tests/data/manifest/blktap.json
+++ b/tests/data/manifest/blktap.json
@@ -1,12 +1,1 @@
-{
-    "spec": {
-        "source0": {
-            "url": "http://hg.uk.xensource.com/git/carbon/trunk/blktap.git/snapshot/refs/tags/v3.3.0#/blktap-3.3.0.tar.gz", 
-            "sha1": "ddb48b561342d7742ec1dbd6c4987c1f4add9387"
-        }
-    }, 
-    "lnk": {
-        "url": "http://hg.uk.xensource.com/git/carbon/trunk/blktap.pg.git/snapshot/refs/heads/master#/blktap.patches.tar", 
-        "sha1": "ac9032660c02be11afdb7cc8ad23be2f1aa9b7ce"
-    }
-}
+{"sources": {}, "patchqueues": {"PatchQueue0": {"url": "http://hg.uk.xensource.com/git/carbon/trunk/blktap.pg.git/snapshot/refs/heads/master#/blktap.patches.tar", "prefix": null, "sha1": "ac9032660c02be11afdb7cc8ad23be2f1aa9b7ce", "commitish": null}}, "spec": {"source0": {"url": "http://hg.uk.xensource.com/git/carbon/trunk/blktap.git/snapshot/refs/tags/v3.3.0#/blktap-3.3.0.tar.gz", "sha1": "ddb48b561342d7742ec1dbd6c4987c1f4add9387"}}, "archives": {}}

--- a/tests/data/manifest/blktap.lnk
+++ b/tests/data/manifest/blktap.lnk
@@ -1,6 +1,7 @@
 {
-    "URL": "http://hg.uk.xensource.com/git/carbon/trunk/blktap.pg.git/snapshot/refs/heads/master#/blktap.patches.tar",
-    "specfile": "blktap.spec",
-    "patchqueue": "master",
-    "branch": "trunk"
+    "SchemaVersion": "3",
+    "PatchQueue0": {
+        "URL": "http://hg.uk.xensource.com/git/carbon/trunk/blktap.pg.git/snapshot/refs/heads/master#/blktap.patches.tar",
+        "patchqueue": "master"
+    }
 }

--- a/tests/data/manifest/blktap.lnk
+++ b/tests/data/manifest/blktap.lnk
@@ -2,6 +2,6 @@
     "SchemaVersion": "3",
     "PatchQueue0": {
         "URL": "http://hg.uk.xensource.com/git/carbon/trunk/blktap.pg.git/snapshot/refs/heads/master#/blktap.patches.tar",
-        "patchqueue": "master"
+        "prefix": "master"
     }
 }

--- a/tests/data/manifest/branding-xenserver.json
+++ b/tests/data/manifest/branding-xenserver.json
@@ -1,8 +1,11 @@
 {
+    "sources": {}, 
+    "patchqueues": {}, 
     "spec": {
         "source0": {
             "url": "https://code.citrite.net/rest/archive/latest/projects/XS/repos/branding/archive?format=tar.gz#/branding-xenserver.tar.gz", 
             "sha1": "39ae2ff11cfc5bde4724c67aae0aca77d2636664"
         }
-    }
+    }, 
+    "archives": {}
 }

--- a/tests/data/manifest/vhostmd.json
+++ b/tests/data/manifest/vhostmd.json
@@ -1,12 +1,18 @@
 {
+    "sources": {}, 
+    "patchqueues": {}, 
     "spec": {
         "source0": {
             "url": "https://repo.citrite.net/xs-local-contrib/vhostmd/vhostmd-0.4.tar.gz", 
             "sha1": null
         }
     }, 
-    "lnk": {
-        "url": "https://code.citrite.net/rest/archive/latest/projects/XS/repos/vhostmd/archive?at=refs%2Fheads%2Fxenserver_patches&format=tar#/vhostmd.patches.tar", 
-        "sha1": "8c25514011ff2081ccb6b988f2395d2be83570e7"
+    "archives": {
+        "Archive0": {
+            "url": "https://code.citrite.net/rest/archive/latest/projects/XS/repos/vhostmd/archive?at=refs%2Fheads%2Fxenserver_patches&format=tar#/vhostmd.patches.tar", 
+            "prefix": null, 
+            "sha1": "8c25514011ff2081ccb6b988f2395d2be83570e7", 
+            "commitish": null
+        }
     }
 }

--- a/tests/data/manifest/vhostmd.lnk
+++ b/tests/data/manifest/vhostmd.lnk
@@ -1,5 +1,7 @@
 {
-    "URL": "https://code.citrite.net/rest/archive/latest/projects/XS/repos/vhostmd/archive?at=refs%2Fheads%2Fxenserver_patches&format=tar#/vhostmd.patches.tar",
-    "specfile": "SPECS/vhostmd.spec",
-    "patches": "SOURCES"
+    "SchemaVersion": "3",
+    "Archive0": {
+        "URL": "https://code.citrite.net/rest/archive/latest/projects/XS/repos/vhostmd/archive?at=refs%2Fheads%2Fxenserver_patches&format=tar#/vhostmd.patches.tar",
+        "prefix": "SOURCES"
+    }
 }

--- a/tests/specs/SPECS/PQ.lnk
+++ b/tests/specs/SPECS/PQ.lnk
@@ -2,6 +2,6 @@
 	"SchemaVersion": "3",
 	"PatchQueue0": {
 		"URL": "https://github.com/xenserver/nsource/archive/PQ.tar.gz",
-		"patchqueue": "master"
+		"prefix": "master"
 	}
 }

--- a/tests/specs/SPECS/RP.lnk
+++ b/tests/specs/SPECS/RP.lnk
@@ -1,7 +1,7 @@
 {
 	"SchemaVersion": "3",
-	"Patch0": {
+	"Archive0": {
 		"URL": "https://github.com/xenserver/nsource/archive/RP.tar.gz",
-		"patches": "SOURCES"
+		"prefix": "SOURCES"
 	}
 }

--- a/tests/test_link.py
+++ b/tests/test_link.py
@@ -17,6 +17,14 @@ class TestLink(unittest.TestCase):
 }
 """  # nopep8
 
+    v1_link_sv = """
+{
+    "SchemaVersion": "1",
+    "URL": "https://code.citrite.net/rest/archive/latest/projects/XS/repos/sm.pg/archive?at=1.14&format=tar#/sm.patches.tar",
+    "patchqueue": "master"
+}
+"""  # nopep8
+
     v2_link = """
 {
     "SchemaVersion": "2",
@@ -41,6 +49,42 @@ class TestLink(unittest.TestCase):
 }
 """  # nopep8
 
+    v3_link = """
+{
+    "SchemaVersion": "3",
+    "Source0":
+    {
+        "URL": "https://code.citrite.net/rest/archive/latest/projects/XSU/repos/sbd/archive?at=v1.3.0&format=tar"
+    },
+    "Source1":
+    {
+        "URL": "Blah"
+    },
+    "Archive0":
+    {
+        "URL": "https://code.citrite.net/rest/archive/latest/projects/~MARKSY/repos/sbd-centos/archive?at=f46b0e608f5&format=tar",
+        "prefix": "SOURCES"
+    },
+    "PatchQueue0":
+    {
+        "URL": "https://code.citrite.net/rest/archive/latest/projects/~MARKSY/repos/sbd.pg/archive?at=f4d3fb5&format=tar",
+        "prefix": "master"
+    }
+}
+"""  # nopep8
+
+    @mock.patch('planex.link.open', mock.mock_open(read_data=v1_link))
+    def test_schema_missing(self):
+        """ Test that the schema version is required """
+        with self.assertRaises(planex.link.UnsupportedProperty):
+            planex.link.Link('test_v1.lnk')
+
+    @mock.patch('planex.link.open', mock.mock_open(read_data=v1_link_sv))
+    def test_schema_v1(self):
+        """ Test that the schema version of a v1 lnk is not supported """
+        with self.assertRaises(planex.link.UnsupportedProperty):
+            planex.link.Link('test_v1.lnk')
+
     @mock.patch('planex.link.open', mock.mock_open(read_data=v2_link))
     def test_schema_v2(self):
         """ Test that the schema version of a v2 lnk is 2 """
@@ -48,32 +92,12 @@ class TestLink(unittest.TestCase):
 
         self.assertEquals(2, link.schema_version)
 
-    @mock.patch('planex.link.open', mock.mock_open(read_data=v1_link))
-    def test_schema_v1(self):
-        """ Test that the schema version of a v1 lnk is coerced to 1 """
-        link = planex.link.Link('test_v1.lnk')
+    @mock.patch('planex.link.open', mock.mock_open(read_data=v3_link))
+    def test_schema_v3(self):
+        """ Test that the schema version of a v3 lnk is 3 """
+        link = planex.link.Link('test_v3.lnk')
 
-        self.assertEquals(1, link.schema_version)
-
-    @mock.patch('planex.link.open', mock.mock_open(read_data=v1_link))
-    def test_patch_sources_v1(self):
-        """ Test that we get an error if asking for patch_sources on v1"""
-
-        link = planex.link.Link('test_v1.lnk')
-        sources = None
-        with self.assertRaises(planex.link.UnsupportedProperty):
-            sources = link.patch_sources
-        self.assertIsNone(sources)
-
-    @mock.patch('planex.link.open', mock.mock_open(read_data=v1_link))
-    def test_patchqueue_sources_v1(self):
-        """ Test that we get an error if asking for patchqueue_sources on v1"""
-
-        link = planex.link.Link('test_v1.lnk')
-        sources = None
-        with self.assertRaises(planex.link.UnsupportedProperty):
-            sources = link.patchqueue_sources
-        self.assertIsNone(sources)
+        self.assertEquals(3, link.schema_version)
 
     @mock.patch('planex.link.open', mock.mock_open(read_data=v2_link))
     def test_patch_sources_v2(self):
@@ -84,6 +108,31 @@ class TestLink(unittest.TestCase):
         self.assertIn('Patch0', sources)
         self.assertNotIn('PatchQueue0', sources)
 
+    @mock.patch('planex.link.open', mock.mock_open(read_data=v3_link))
+    def test_patch_sources_v3(self):
+        """ Test that we get a failure if asking for patch_sources on v3"""
+
+        link = planex.link.Link('test_v3.lnk')
+        with self.assertRaises(planex.link.UnsupportedProperty):
+            _ = link.patch_sources
+
+    @mock.patch('planex.link.open', mock.mock_open(read_data=v2_link))
+    def test_archives_v2(self):
+        """ Test that we get a failure if asking for archives on v2"""
+
+        link = planex.link.Link('test_v2.lnk')
+        with self.assertRaises(planex.link.UnsupportedProperty):
+            _ = link.archives
+
+    @mock.patch('planex.link.open', mock.mock_open(read_data=v3_link))
+    def test_archives_v3(self):
+        """ Test that we get sources if asking for archives on v3"""
+
+        link = planex.link.Link('test_v3.lnk')
+        sources = link.archives
+        self.assertIn('Archive0', sources)
+        self.assertNotIn('PatchQueue0', sources)
+
     @mock.patch('planex.link.open', mock.mock_open(read_data=v2_link))
     def test_patchqueue_sources_v2(self):
         """ Test that we get sources if asking for patchqueue_sources on v2"""
@@ -92,20 +141,10 @@ class TestLink(unittest.TestCase):
         sources = link.patchqueue_sources
         self.assertIn('PatchQueue0', sources)
 
-    @mock.patch('planex.link.open', mock.mock_open(read_data=v1_link))
-    def test_patchqueue_v1(self):
-        """ Test that we get data for patchqueue on v1"""
+    @mock.patch('planex.link.open', mock.mock_open(read_data=v3_link))
+    def test_patchqueue_sources_v3(self):
+        """ Test that we get sources if asking for patchqueue_sources on v2"""
 
-        link = planex.link.Link('test_v1.lnk')
-        patchqueue = link.patchqueue
-        self.assertEqual('master', patchqueue)
-
-    @mock.patch('planex.link.open', mock.mock_open(read_data=v2_link))
-    def test_patchqueue_v2(self):
-        """ Test that we get an error for patchqueue on v2"""
-
-        link = planex.link.Link('test_v2.lnk')
-        patchqueue = None
-        with self.assertRaises(planex.link.UnsupportedProperty):
-            patchqueue = link.patchqueue
-        self.assertIsNone(patchqueue)
+        link = planex.link.Link('test_v3.lnk')
+        sources = link.patchqueue_sources
+        self.assertIn('PatchQueue0', sources)

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -62,28 +62,32 @@ class BasicTests(unittest.TestCase):
 
         self.assertEqual(manifest, self.expected_manifest[self.name_1])
 
-    @mock.patch('planex.git.ls_remote')
-    def test_generate_manifest_2(self, mock_git_ls_remote):
-        """Manifest for source tarball and patchqueue (specfile and lnkfile)"""
+    # @mock.patch('planex.git.ls_remote')
+    # def test_generate_manifest_2(self, mock_git_ls_remote):
+    #     """
+    #     Manifest for source tarball and patchqueue (specfile and lnkfile)
+    #     """
 
-        mock_git_ls_remote.return_value = self.git_ls_remote_out[self.name_2]
+    #     mock_git_ls_remote.return_value = self.git_ls_remote_out[
+    #         self.name_2]
 
-        manifest = planex.cmd.manifest.generate_manifest(
-            self.spec[self.name_2],
-            self.link[self.name_2]
-        )
+    #     manifest = planex.cmd.manifest.generate_manifest(
+    #         self.spec[self.name_2],
+    #         self.link[self.name_2]
+    #     )
 
-        self.assertEqual(manifest, self.expected_manifest[self.name_2])
+    #     self.assertEqual(manifest, self.expected_manifest[self.name_2])
 
-    @mock.patch('planex.git.ls_remote')
-    def test_generate_manifest_3(self, mock_git_ls_remote):
-        """Manifest for repo and patchqueue (specfile and lnkfile)"""
+    # @mock.patch('planex.git.ls_remote')
+    # def test_generate_manifest_3(self, mock_git_ls_remote):
+    #     """Manifest for repo and patchqueue (specfile and lnkfile)"""
 
-        mock_git_ls_remote.side_effect = self.git_ls_remote_out[self.name_3]
+    #     mock_git_ls_remote.side_effect = self.git_ls_remote_out[
+    #         self.name_3]
 
-        manifest = planex.cmd.manifest.generate_manifest(
-            self.spec[self.name_3],
-            self.link[self.name_3]
-        )
+    #     manifest = planex.cmd.manifest.generate_manifest(
+    #         self.spec[self.name_3],
+    #         self.link[self.name_3]
+    #     )
 
-        self.assertEqual(manifest, self.expected_manifest[self.name_3])
+    #     self.assertEqual(manifest, self.expected_manifest[self.name_3])

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -62,32 +62,32 @@ class BasicTests(unittest.TestCase):
 
         self.assertEqual(manifest, self.expected_manifest[self.name_1])
 
-    # @mock.patch('planex.git.ls_remote')
-    # def test_generate_manifest_2(self, mock_git_ls_remote):
-    #     """
-    #     Manifest for source tarball and patchqueue (specfile and lnkfile)
-    #     """
+    @mock.patch('planex.git.ls_remote')
+    def test_generate_manifest_2(self, mock_git_ls_remote):
+        """
+        Manifest for source tarball and patchqueue (specfile and lnkfile)
+        """
 
-    #     mock_git_ls_remote.return_value = self.git_ls_remote_out[
-    #         self.name_2]
+        mock_git_ls_remote.return_value = self.git_ls_remote_out[
+            self.name_2]
 
-    #     manifest = planex.cmd.manifest.generate_manifest(
-    #         self.spec[self.name_2],
-    #         self.link[self.name_2]
-    #     )
+        manifest = planex.cmd.manifest.generate_manifest(
+            self.spec[self.name_2],
+            self.link[self.name_2]
+        )
 
-    #     self.assertEqual(manifest, self.expected_manifest[self.name_2])
+        self.assertEqual(manifest, self.expected_manifest[self.name_2])
 
-    # @mock.patch('planex.git.ls_remote')
-    # def test_generate_manifest_3(self, mock_git_ls_remote):
-    #     """Manifest for repo and patchqueue (specfile and lnkfile)"""
+    @mock.patch('planex.git.ls_remote')
+    def test_generate_manifest_3(self, mock_git_ls_remote):
+        """Manifest for repo and patchqueue (specfile and lnkfile)"""
 
-    #     mock_git_ls_remote.side_effect = self.git_ls_remote_out[
-    #         self.name_3]
+        mock_git_ls_remote.side_effect = self.git_ls_remote_out[
+            self.name_3]
 
-    #     manifest = planex.cmd.manifest.generate_manifest(
-    #         self.spec[self.name_3],
-    #         self.link[self.name_3]
-    #     )
+        manifest = planex.cmd.manifest.generate_manifest(
+            self.spec[self.name_3],
+            self.link[self.name_3]
+        )
 
-    #     self.assertEqual(manifest, self.expected_manifest[self.name_3])
+        self.assertEqual(manifest, self.expected_manifest[self.name_3])

--- a/tests/test_patchqueue.py
+++ b/tests/test_patchqueue.py
@@ -10,7 +10,7 @@ from nose.plugins.attrib import attr
 import tests.strategies as tst
 
 import planex.patchqueue
-from planex.spec import Spec
+from planex.spec import Spec, Blob
 
 
 class BasicTests(unittest.TestCase):
@@ -42,9 +42,9 @@ class BasicTests(unittest.TestCase):
         """Patches are inserted into rewritten spec file"""
         spec = Spec("tests/data/manifest/branding-xenserver.spec",
                     check_package_name=False)
-        spec.add_patch(0, "first.patch", "dummy")
-        spec.add_patch(1, "second.patch", "dummy")
-        spec.add_patch(2, "third.patch", "dummy")
+        spec.add_patch(0, Blob(spec, "first.patch", "dummy"))
+        spec.add_patch(1, Blob(spec, "second.patch", "dummy"))
+        spec.add_patch(2, Blob(spec, "third.patch", "dummy"))
 
         rewritten = spec.rewrite_spec()
         self.assertIn("Patch0: first.patch\n", rewritten)
@@ -55,9 +55,9 @@ class BasicTests(unittest.TestCase):
         """Patches with the same index override each other"""
         spec = Spec("tests/data/manifest/branding-xenserver.spec",
                     check_package_name=False)
-        spec.add_patch(0, "first.patch", "dummy")
-        spec.add_patch(1, "second.patch", "dummy")
-        spec.add_patch(0, "third.patch", "dummy")
+        spec.add_patch(0, Blob(spec, "first.patch", "dummy"))
+        spec.add_patch(1, Blob(spec, "second.patch", "dummy"))
+        spec.add_patch(0, Blob(spec, "third.patch", "dummy"))
 
         rewritten = spec.rewrite_spec()
         self.assertNotIn("Patch0: first.patch\n", rewritten)
@@ -68,21 +68,21 @@ class BasicTests(unittest.TestCase):
         """Patchqueue application succeeds if %autosetup is present"""
         spec = Spec("tests/data/manifest/branding-xenserver.spec",
                     check_package_name=False)
-        spec.add_patch(0, "first.patch", "dummy")
+        spec.add_patch(0, Blob(spec, "first.patch", "dummy"))
         rewritten = spec.rewrite_spec()
         self.assertIn("Patch0: first.patch\n", rewritten)
 
     def test_autosetup_missing(self):
         """Patchqueue application fails if %autosetup is not present"""
         spec = Spec("tests/data/ocaml-uri.spec", check_package_name=False)
-        spec.add_patch(0, "first.patch", "dummy")
+        spec.add_patch(0, Blob(spec, "first.patch", "dummy"))
         with self.assertRaises(planex.patchqueue.SpecMissingAutosetup):
             spec.rewrite_spec()
 
     def test_autosetup_disabled(self):
         """Patchqueue application fails if %autosetup is not present"""
         spec = Spec("tests/data/ocaml-uri.spec", check_package_name=False)
-        spec.add_patch(0, "first.patch", "dummy")
+        spec.add_patch(0, Blob(spec, "first.patch", "dummy"))
         spec.disable_autosetup()
         rewritten = spec.rewrite_spec()
         self.assertIn("Patch0: first.patch\n", rewritten)

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -115,10 +115,10 @@ class RpmTests(unittest.TestCase):
 
     def test_resources_override(self):
         """Package source paths and URLs are correct"""
-        self.spec.add_source(0, "http://elsewhere", "link1")
-        self.spec.add_source(3, "http://additional", "link2")
-        self.spec.add_patch(1, "http://a.n.other", "link3")
-        self.spec.add_patch(3, "http://extra", "link4")
+        self.spec.add_source(0, Blob(self.spec, "http://elsewhere", "link1"))
+        self.spec.add_source(3, Blob(self.spec, "http://additional", "link2"))
+        self.spec.add_patch(1, Blob(self.spec, "http://a.n.other", "link3"))
+        self.spec.add_patch(3, Blob(self.spec, "http://extra", "link4"))
         self.assertEqual(
             self.spec.resources(),
             [Blob(self.spec, "http://elsewhere", "link1"),
@@ -134,10 +134,10 @@ class RpmTests(unittest.TestCase):
 
     def test_resources_extras(self):
         """Package source paths and URLs are correct"""
-        self.spec.add_archive(0, "http://foo/patches.tar",
-                              "link1", "SOURCES/")
-        self.spec.add_patchqueue(0, "http://foo/patchqueue.tar",
-                                 "link1", "PATCHES/")
+        self.spec.add_archive(0, Archive(self.spec, "http://foo/patches.tar",
+                                         "link1", "SOURCES/"))
+        self.spec.add_patchqueue(0, Patchqueue(self.spec, "http://foo/patchqueue.tar",
+                                               "link1", "PATCHES/"))
         self.assertEqual(
             self.spec.resources(),
             [Blob(self.spec,
@@ -173,8 +173,8 @@ class RpmTests(unittest.TestCase):
             self.spec.resource("somewhere/cohttp0.patch"),
             Blob(self.spec, "cohttp0.patch",
                  "tests/data/ocaml-cohttp.spec"))
-        self.spec.add_archive(0, "http://foo/patches.tar",
-                              "link1", "SOURCES/")
+        self.spec.add_archive(0, Archive(self.spec, "http://foo/patches.tar",
+                                         "link1", "SOURCES/"))
         self.assertEqual(
             self.spec.resource("somewhere/patches.tar"),
             Archive(self.spec, "http://foo/patches.tar", "link1",

--- a/tests/test_spec.py
+++ b/tests/test_spec.py
@@ -136,7 +136,8 @@ class RpmTests(unittest.TestCase):
         """Package source paths and URLs are correct"""
         self.spec.add_archive(0, Archive(self.spec, "http://foo/patches.tar",
                                          "link1", "SOURCES/"))
-        self.spec.add_patchqueue(0, Patchqueue(self.spec, "http://foo/patchqueue.tar",
+        self.spec.add_patchqueue(0, Patchqueue(self.spec,
+                                               "http://foo/patchqueue.tar",
                                                "link1", "PATCHES/"))
         self.assertEqual(
             self.spec.resources(),


### PR DESCRIPTION
This PR removes leftovers of the SchemaVersion:1 parsing, improves the versioning and updates the semantics of the v3 pins.

It also raises an interesting issue with `planex-manifest`, since links v2 it has become completely useless for links and pins.

This should resolve #539 and #540 