### PR TITLE
planex-pin does not know about the new pin format

### DIFF
--- a/planex/Makefile.rules
+++ b/planex/Makefile.rules
@@ -103,11 +103,6 @@ $(TOPDIR)/SOURCES/%:
 	$(AT) mkdir -p $(@D)
 	$(AT)$(FETCH) $(FETCH_FLAGS) $^ $@
 
-# Create a patchqueue tarball for a pinned package.
-# Pinned patchqueues are always regenerated.
-.PHONY: FORCE
-FORCE:
-
 
 ############################################################################
 # RPM build rules

--- a/planex/cmd/clone.py
+++ b/planex/cmd/clone.py
@@ -120,6 +120,8 @@ def apply_patchqueue(base_repo, pq_repo, pq_dir):
                               cwd=base_repo.working_dir)
 
 # pylint: disable=too-many-locals
+
+
 def main(argv=None):
     """
     Entry point

--- a/planex/cmd/clone.py
+++ b/planex/cmd/clone.py
@@ -147,8 +147,8 @@ def main(argv=None):
                    for (url1, commitish1) in gathered
                    for (url2, commitish2) in gathered
                    if url1 == url2):
-                sys.exit("Cloning two git repositories with the same name "
-                         "but different commitish is not supported")
+                sys.exit("error: cloning two git repositories with the same "
+                         "name but different commitish is not supported")
 
             for url, commitish in gathered:
                 print('echo "Cloning %s"' % url)
@@ -163,11 +163,18 @@ def main(argv=None):
                            for _, pq in pin.patchqueue_sources.items()
                            if pq.get('commitish', False)]
 
+            if not sources:
+                sys.exit("error: planex-clone requires Source0 to point to "
+                         "a git repository.")
+            if pin.patchqueue_sources and not patchqueues:
+                sys.exit("error: planex-clone requires PatchQueue0 to point to "
+                         "a git repository.")
+
             if len(sources) != 1 and len(patchqueues) > 1:
-                raise NotImplementedError(
-                    "planex-clone does not support the cloning and assembly "
-                    "of multiple sources and patchqueues, currently this "
-                    "case needs to be handled by hands.")
+                sys.exit(
+                    "error: planex-clone does not support the cloning and "
+                    "assembly of multiple sources and patchqueues, currently "
+                    "this case needs to be handled by hands.")
             try:
                 src_url, src_commitish = sources.pop()
                 print("Cloning %s" % src_url)

--- a/planex/cmd/clone.py
+++ b/planex/cmd/clone.py
@@ -119,7 +119,7 @@ def apply_patchqueue(base_repo, pq_repo, pq_dir):
         subprocess.check_call(['guilt', 'push', '--all'],
                               cwd=base_repo.working_dir)
 
-
+# pylint: disable=too-many-locals
 def main(argv=None):
     """
     Entry point
@@ -174,8 +174,8 @@ def main(argv=None):
                 sys.exit("error: planex-clone requires Source0 to point to "
                          "a git repository.")
             if pin.patchqueue_sources and not patchqueues:
-                sys.exit("error: planex-clone requires PatchQueue0 to point to "
-                         "a git repository.")
+                sys.exit("error: planex-clone requires PatchQueue0 to point "
+                         "to a git repository.")
 
             if len(sources) != 1 and len(patchqueues) > 1:
                 sys.exit(

--- a/planex/cmd/clone.py
+++ b/planex/cmd/clone.py
@@ -136,7 +136,8 @@ def main(argv=None):
                          if pq.get('commitish', False)])
 
             # Prevent double-cloning of a repository
-            gathered = set((g['URL'], g['commitish']) for g in gathered)
+            gathered = set((gath['URL'], gath['commitish'])
+                           for gath in gathered)
 
             if gathered:
                 print('echo "Clones for %s"' % pinpath)

--- a/planex/cmd/clone.py
+++ b/planex/cmd/clone.py
@@ -3,6 +3,7 @@ planex-clone: Checkout sources referred to by a pin file
 """
 from __future__ import print_function
 
+import errno
 from string import Template
 import argparse
 from os import symlink
@@ -96,7 +97,13 @@ def apply_patchqueue(base_repo, pq_repo, pq_dir):
                            base_repo.active_branch.name)
     branch_path = dirname(base_repo.active_branch.name)
     util.makedirs(dirname(patchqueue_path))
-    symlink(relpath(pq_dir, branch_path), patchqueue_path)
+    try:
+        symlink(relpath(pq_dir, branch_path), patchqueue_path)
+    except OSError as err:
+        if err.errno == errno.EEXIST:
+            pass
+        else:
+            raise
 
     # Create empty guilt status for the branch
     status = join(patchqueue_path, 'status')

--- a/planex/cmd/depend.py
+++ b/planex/cmd/depend.py
@@ -62,8 +62,8 @@ def download_rpm_sources(spec):
             print('%s: %s' % (resource.path, spec.specpath()))
             if resource.defined_by != spec.specpath():
                 print("%s: %s" % (resource.path, resource.defined_by))
-            if resource.force_rebuild:
-                print("%s: %s" % (resource.path, "FORCE"))
+            # if resource.force_rebuild:
+            #     print("%s: %s" % (resource.path, "FORCE"))
 
 
 def build_rpm_from_srpm(spec):

--- a/planex/cmd/fetch.py
+++ b/planex/cmd/fetch.py
@@ -15,7 +15,7 @@ import requests
 from requests.adapters import HTTPAdapter
 from requests.adapters import Retry
 try:
-    import requests.packages.urlparse
+    import requests.packages.urlparse as urlparse
 except ImportError:
     import urlparse
 

--- a/planex/cmd/fetch.py
+++ b/planex/cmd/fetch.py
@@ -182,8 +182,12 @@ def fetch_source(args):
         reponame = os.path.basename(url.path).rsplit(".git")[0]
         repo = git.Repo(os.path.join("repos", reponame))
         with open(resource.path, "wb") as output:
+            if resource.prefix is not None:
+                prefix = str(resource.prefix)
+            else:
+                prefix = None
             repo.archive(output, treeish=str(resource.commitish),
-                         prefix=str(resource.prefix))
+                         prefix=prefix)
 
     elif url.scheme in ['', 'file'] and url.netloc == '':
         shutil.copyfile(url.path, resource.path)

--- a/planex/cmd/pin.py
+++ b/planex/cmd/pin.py
@@ -122,14 +122,13 @@ def parse_args_or_exit(argv=None):
                        help="Path of the pinfile to write. "
                             "It overwrites the file if present.")
 
-    overrs = parser.add_mutually_exclusive_group()
-    overrs.add_argument("--source-override", dest="source", default=None,
+    parser.add_argument("--override-source", dest="source", default=None,
                         help="Path to a tarball or url of a git "
                              "repository in the form ssh://GitURL#commitish. "
                              "When used the pin will get rid of any "
                              "pre-existing source, archive or patchqueue "
                              "and use the provided path as Source0.")
-    overrs.add_argument("--patchqueue-override", dest="patchqueue",
+    parser.add_argument("--override-patchqueue", dest="patchqueue",
                         default=None,
                         help="Path to a tarball or url of a git "
                              "repository in the form ssh://GitURL#commitish. "

--- a/planex/cmd/pin.py
+++ b/planex/cmd/pin.py
@@ -140,7 +140,7 @@ def main(argv=None):
     spec = load_spec_and_lnk(xs_path, package_name)
     pin = get_pin_content(args, spec)
 
-    print(json.dumps(pin, indent=2))
+    print(json.dumps(pin, indent=2, sort_keys=True))
 
     output = args.output
     if args.write:
@@ -150,6 +150,6 @@ def main(argv=None):
         path = os.path.dirname(output)
         if os.path.exists(path):
             with open(output, "w") as out:
-                json.dump(pin, out, indent=2)
+                json.dump(pin, out, indent=2, sort_keys=True)
         else:
             sys.exit("Error: path {} does not exist.".format(path))

--- a/planex/cmd/pin.py
+++ b/planex/cmd/pin.py
@@ -5,6 +5,7 @@ in xenserver-specs/repos/ to override the spec/lnk
 from __future__ import print_function
 
 import argparse
+import copy
 import json
 import os
 import sys
@@ -90,12 +91,15 @@ def get_pin_content(args, spec):
         pinfile["PatchQueue0"] = {"URL": url}
         if commitish is not None:
             pinfile["PatchQueue0"]["commitish"] = commitish
+            pinfile["PatchQueue0"]["prefix"] = resources["PatchQueue0"].prefix
 
         # Note that in all our current link files, when both a PQ
         # and an Archive are present, these point to the same tarball.
         # This, by default, planex-pin will overwrite the Archive0 with
         # the same content as PatchQueue0
-        pinfile["Archive0"] = pinfile["PatchQueue0"]
+        if "Archive0" in resources:
+            pinfile["Archive0"] = copy.deepcopy(pinfile["PatchQueue0"])
+            pinfile["Archive0"]["prefix"] = resources["Archive0"].prefix
 
     return pinfile
 

--- a/planex/cmd/pin.py
+++ b/planex/cmd/pin.py
@@ -65,8 +65,17 @@ def populate_pinfile(pinfile, args, resources):
     """
     for name, source in resources.items():
 
+        # If we are overriding Source0, we still need to keep other
+        # eventual sources
+        if args.source is not None \
+                and (name == "Source0" or "Source" not in name):
+            continue
+        # When we override PatchQueue0, we get rid of all the other
+        # patchqueues
         if args.patchqueue is not None and "PatchQueue" in name:
             continue
+        # Patches are defined in the spec and could be overridden with
+        # Archives, but we do not put them in the link and pin files
         if "Patch" in name and "PatchQueue" not in name:
             continue
 
@@ -104,8 +113,8 @@ def get_pin_content(args, spec):
         pinfile["Source0"] = {"URL": url}
         if commitish is not None:
             pinfile["Source0"]["commitish"] = commitish
-    else:
-        populate_pinfile(pinfile, args, resources)
+
+    populate_pinfile(pinfile, args, resources)
 
     if args.patchqueue is not None:
         url, commitish = repo_or_path(args.patchqueue)

--- a/planex/cmd/pin.py
+++ b/planex/cmd/pin.py
@@ -99,9 +99,11 @@ def parse_args_or_exit(argv=None):
     """
 
     parser = argparse.ArgumentParser(
-        description="Create a .pin file pointing to a repository "
-                    "in $CWD/repos. You must run "
-                    "this tool from the root of a spec repository.",
+        description="Create a .pin file for PACKAGE. "
+                    "Needs to run from the root of a spec repository. "
+                    "Note that when URL is an ssh url to a git repository, "
+                    "planex will first look for a repository with the "
+                    "same name cloned in the $CWD/repos folder.",
         parents=[common_base_parser()])
     parser.add_argument("package", metavar="PACKAGE", help="package name")
 
@@ -116,14 +118,14 @@ def parse_args_or_exit(argv=None):
     overrs = parser.add_mutually_exclusive_group()
     overrs.add_argument("--source-override", dest="source", default=None,
                         help="Path to a tarball or url of a git "
-                             "repository in the form URL:commitish."
+                             "repository in the form URL:commitish. "
                              "When used the pin will get rid of any "
                              "pre-existing source, archive or patchqueue "
                              "and use the provided path as Source0.")
     overrs.add_argument("--patchqueue-override", dest="patchqueue",
                         default=None,
                         help="Path to a tarball or url of a git "
-                             "repository in the form URL:commitish."
+                             "repository in the form URL:commitish. "
                              "When used the pin will get rid of any "
                              "pre-existing patchqueue and use the provided "
                              "path as PatchQueue0.")

--- a/planex/cmd/pin.py
+++ b/planex/cmd/pin.py
@@ -45,14 +45,16 @@ def repo_or_path(arg):
     Heuristic. Parse URL:commitish into (URL, commitish) and anything else into
     (URL, None)
     """
-    split = arg.strip().split(":")
-    if len(split) > 2 or not split:
-        raise ValueError(
-            "Expected URL or URL:commitish but got {}".format(arg))
-    elif len(split) == 2:
+    if arg.startswith("ssh://"):
+        split = arg.split("#")
+        if len(split) > 2 or not split:
+            raise ValueError(
+                "Expected URL or ssh://URL#commitish but got {}".format(arg))
+        if len(split) == 1:
+            return (arg, None)
         return tuple(split)
-    else:
-        return (split[0], None)
+
+    return (arg, None)
 
 # pylint: disable=too-many-branches
 
@@ -123,14 +125,14 @@ def parse_args_or_exit(argv=None):
     overrs = parser.add_mutually_exclusive_group()
     overrs.add_argument("--source-override", dest="source", default=None,
                         help="Path to a tarball or url of a git "
-                             "repository in the form URL:commitish. "
+                             "repository in the form ssh://GitURL#commitish. "
                              "When used the pin will get rid of any "
                              "pre-existing source, archive or patchqueue "
                              "and use the provided path as Source0.")
     overrs.add_argument("--patchqueue-override", dest="patchqueue",
                         default=None,
                         help="Path to a tarball or url of a git "
-                             "repository in the form URL:commitish. "
+                             "repository in the form ssh://GitURL#commitish. "
                              "When used the pin will get rid of any "
                              "pre-existing patchqueue and use the provided "
                              "path as PatchQueue0.")

--- a/planex/cmd/pin.py
+++ b/planex/cmd/pin.py
@@ -18,6 +18,7 @@ RPM_DEFINES = [("dist", "pinned"),
                ("_topdir", "."),
                ("_sourcedir", "%_topdir/SOURCES/%name")]
 
+
 def load_spec_and_lnk(repo_path, package_name):
     """
     Return the Spec object for
@@ -77,9 +78,7 @@ def get_pin_content(args, spec):
             continue
 
         pinfile[name] = {"URL": source.url}
-        if isinstance(source, GitBlob) \
-                or isinstance(source, GitArchive) \
-                or isinstance(source, GitPatchqueue):
+        if isinstance(source, (GitBlob, GitArchive, GitPatchqueue)):
             pinfile[name]["commititsh"] = source.commitish
         if isinstance(source, Archive):
             pinfile[name]["prefix"] = source.prefix

--- a/planex/cmd/pin.py
+++ b/planex/cmd/pin.py
@@ -57,23 +57,12 @@ def repo_or_path(arg):
 
     return (arg, None)
 
-# pylint: disable=too-many-branches
 
-
-def get_pin_content(args, spec):
+def populate_pinfile(pinfile, args, resources):
     """
-    Generate the pinfile content for a Spec.
+    Update [pinfile] in place with content of resources.
     """
-    pinfile = {"SchemaVersion": "3"}
-
-    if args.source is not None:
-        url, commitish = repo_or_path(args.source)
-        pinfile["Source0"] = {"URL": url}
-        if commitish is not None:
-            pinfile["Source0"]["commitish"] = commitish
-        return pinfile
-
-    for name, source in spec.resources_dict().items():
+    for name, source in resources.items():
 
         if args.patchqueue is not None and "PatchQueue" in name:
             continue
@@ -85,6 +74,22 @@ def get_pin_content(args, spec):
             pinfile[name]["commititsh"] = source.commitish
         if isinstance(source, Archive):
             pinfile[name]["prefix"] = source.prefix
+
+
+def get_pin_content(args, spec):
+    """
+    Generate the pinfile content for a Spec.
+    """
+    resources = spec.resources_dict()
+
+    pinfile = {"SchemaVersion": "3"}
+    if args.source is not None:
+        url, commitish = repo_or_path(args.source)
+        pinfile["Source0"] = {"URL": url}
+        if commitish is not None:
+            pinfile["Source0"]["commitish"] = commitish
+    else:
+        populate_pinfile(pinfile, args, resources)
 
     if args.patchqueue is not None:
         url, commitish = repo_or_path(args.patchqueue)

--- a/planex/cmd/pin.py
+++ b/planex/cmd/pin.py
@@ -89,6 +89,12 @@ def get_pin_content(args, spec):
         if commitish is not None:
             pinfile["PatchQueue0"]["commitish"] = commitish
 
+        # Note that in all our current link files, when both a PQ
+        # and an Archive are present, these point to the same tarball.
+        # This, by default, planex-pin will overwrite the Archive0 with
+        # the same content as PatchQueue0
+        pinfile["Archive0"] = pinfile["PatchQueue0"]
+
     return pinfile
 
 

--- a/planex/cmd/pin.py
+++ b/planex/cmd/pin.py
@@ -14,6 +14,9 @@ from planex.link import Link
 from planex.spec import GitBlob, GitArchive, GitPatchqueue, Archive
 import planex.spec
 
+RPM_DEFINES = [("dist", "pinned"),
+               ("_topdir", "."),
+               ("_sourcedir", "%_topdir/SOURCES/%name")]
 
 def load_spec_and_lnk(repo_path, package_name):
     """
@@ -31,7 +34,7 @@ def load_spec_and_lnk(repo_path, package_name):
 
     linkname = "%s.lnk" % partial_file_path
     link = Link(linkname) if os.path.isfile(linkname) else None
-    spec = planex.spec.load(specname, link=link)
+    spec = planex.spec.load(specname, link=link, defines=RPM_DEFINES)
 
     return spec
 

--- a/planex/cmd/pin.py
+++ b/planex/cmd/pin.py
@@ -49,7 +49,7 @@ def load_spec_and_lnk(repo_path, package_name):
 
 def repo_or_path(arg):
     """
-    Heuristic. Parse URL:commitish into (URL, commitish) and anything else into
+    Heuristic. Parse URL#commitish into (URL, commitish) and anything else into
     (URL, None)
     """
     if arg.startswith("ssh://"):

--- a/planex/cmd/pin.py
+++ b/planex/cmd/pin.py
@@ -86,7 +86,7 @@ def populate_pinfile(pinfile, args, resources):
 
         pinfile[name] = {}
         if isinstance(source, (GitBlob, GitArchive, GitPatchqueue)):
-            url = source.url,
+            url = source.url
             commitish = source.commitish
         else:
             # heuristically try to get a repo

--- a/planex/spec.py
+++ b/planex/spec.py
@@ -654,6 +654,20 @@ class Spec(object):
         assert isinstance(patchqueue, Patchqueue)
         self._patchqueues[index] = patchqueue
 
+    def resources_dict(self):
+        """Return all resources from the spec in a dict"""
+        iterator = [
+            (self._sources, "Source"),
+            (self._patches, "Patch"),
+            (self._archives, "Archive"),
+            (self._patchqueues, "PatchQueue")
+        ]
+        resources = {}
+        for resource, string in iterator:
+            for key, value in resource.items():
+                resources["{}{}".format(string, key)] = value
+        return resources
+
     def resources(self):
         """List all resources to be packed into the source package"""
 

--- a/planex/spec.py
+++ b/planex/spec.py
@@ -197,17 +197,10 @@ class GitBlob(Blob):
     """
 
     # pylint: disable=too-many-arguments
-    def __init__(self, spec, url, defined_by, prefix, commitish):
+    def __init__(self, spec, url, defined_by, commitish):
         with rpm_macros(spec.macros, nevra(spec.spec.sourceHeader)):
             super(GitBlob, self).__init__(spec, url, defined_by)
-            self._prefix = rpm.expandMacro(prefix)
             self._commitish = rpm.expandMacro(commitish)
-
-    @property
-    @expandmacros
-    def prefix(self):
-        """Return the directory prefix of files in this resource"""
-        return os.path.normpath(self._prefix) + "/"
 
     @property
     @expandmacros
@@ -415,8 +408,7 @@ def update_with_schema_version_3(spec, link):
         idx = _parse_name(name)
         url = value["URL"]
         if url.startswith("ssh://"):
-            source = GitBlob(spec, url, link.path,
-                             value.get("prefix"), value.get("commitish"))
+            source = GitBlob(spec, url, link.path, value.get("commitish"))
         else:
             source = Blob(spec, url, link.path)
         spec.add_source(idx, source)


### PR DESCRIPTION
This should fix #507 and #533.

The new CLI looks like the following:
```
[planex:master local]$ planex-pin --help
usage: planex-pin [-h] [--quiet] [-v] [--version] [-w | -o OUTPUT]
                  [--source-override SOURCE] [--patchqueue-override PATCHQUEUE]
                  PACKAGE
Create a .pin file for PACKAGE. Needs to run from the root of a spec
repository. Note that when URL is an ssh url to a git repository, planex will
first look for a repository with the same name cloned in the $CWD/repos
folder.
positional arguments:
  PACKAGE               package name
optional arguments:
  -h, --help            show this help message and exit
  --quiet, --warn       Only log warnings and errors
  -v, --verbose, --debug
                        Enable debug logging
  --version             show program's version number and exit
  -w, --write           Write pin file in PINS/PACKAGE.pin. It overwrites the
                        file if present.
  -o OUTPUT, --output OUTPUT
                        Path of the pinfile to write. It overwrites the file
                        if present.
  --override-source SOURCE
                        Path to a tarball or url of a git repository in the
                        form URL:commitish. When used the pin will get rid of
                        any pre-existing source, archive or patchqueue and use
                        the provided path as Source0.
  --override-patchqueue PATCHQUEUE
                        Path to a tarball or url of a git repository in the
                        form URL:commitish. When used the pin will get rid of
                        any pre-existing patchqueue and use the provided path
                        as PatchQueue0.
```

Two mutually exclusive flags allow to write on a specific path (`-o`) or on the automatically generated
`PINS/$package_name.pin` path (`-w`). The default behaviour is still to print on `stdout` only.

By default `planex-pin $pkgname` will load `$pkgname.spec` and `$pkgname.lnk` and generate a pin file with the current state of affairs from these two. This means that the new pin files are more verbose than the old one by default, but give a true snapshot of the state of things. The team pins will likely want to remove some of the autogenerated content (like the additional sources).

Two mutually exclusive flags can be used to create a fresh pin with a single `Source0` as source of truth, or a pin file where the `PatchQueue` is replaced by a custom `PatchQueue`.  These are documented in the command help.

This also re-enables `planex-clone` in `Jenkins`. Required for testing the changes.