### PR TITLE
fetch.py: make more robust against tags

### DIFF
--- a/planex/cmd/fetch.py
+++ b/planex/cmd/fetch.py
@@ -187,9 +187,11 @@ def fetch_repo(url, resource):
                      prefix=prefix)
 
     try:
-        sha = repo.refs[str(resource.commitish)].object.rev_parse
+        ref = repo.refs[str(resource.commitish)]
+        sha = ref.object.hexsha
     except (IndexError, AttributeError):
         sha = None
+
     write_originfile(resource.path, repo.remotes.origin.url, sha)
 
 


### PR DESCRIPTION
The ObjectTag does not support rev_parse, using hexsha avoids
issues and works for commitish, tags or branches

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>