### PR TITLE
Add a configuration class

### DIFF
--- a/planex/config.py
+++ b/planex/config.py
@@ -1,0 +1,29 @@
+"""Classes for reading configuration values from INI-style files."""
+
+
+import os.path
+
+from ConfigParser import RawConfigParser
+
+
+class Configuration(object):
+    """Represents a set of configuration options"""
+    # pylint: disable=R0903
+    searchPath = ('/etc/planexrc',
+                  os.path.expanduser('~/.planexrc'),
+                  '.planexrc')
+
+    @classmethod
+    def get(cls, section, option, default=None):
+        """Return the value for an option within a section"""
+        config = cls._config()
+        if config.has_section(section) and config.has_option(section, option):
+            return config.get(section, option)
+        return default
+
+    @classmethod
+    def _config(cls):
+        """Return a ConfigParser object"""
+        config = RawConfigParser()
+        config.read(cls.searchPath)
+        return config

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,40 @@
+"""Tests for Configuration class"""
+
+import os
+import os.path
+import shutil
+import tempfile
+import unittest
+from planex.config import Configuration
+
+
+class ConfigTests(unittest.TestCase):
+    """Basic Configuration class tests"""
+
+    def setUp(self):
+        # Create a temporary directory
+        self.tmpdir = tempfile.mkdtemp()
+        with open(os.path.join(self.tmpdir, '.planexrc'), 'w') as fileh:
+            fileh.write("[sectionA]\n")
+            fileh.write("alpha = abc\n")
+            fileh.write("beta = xyz\n")
+            fileh.write("[sectionB]\n")
+            fileh.write("alpha = pqr\n")
+            fileh.write("gamma = lmn\n")
+        self.cwd = os.getcwd()
+        os.chdir(self.tmpdir)
+
+    def tearDown(self):
+        # Remove the directory after the test
+        os.chdir(self.cwd)
+        shutil.rmtree(self.tmpdir)
+
+    def test_exists(self):
+        """Values for options present are returned"""
+        self.assertEqual(Configuration.get('sectionA', 'alpha'), 'abc')
+        self.assertEqual(Configuration.get('sectionB', 'alpha'), 'pqr')
+
+    def test_defaults(self):
+        """Options that are absent have default values"""
+        self.assertEqual(Configuration.get('sectionA', 'gamma'), None)
+        self.assertEqual(Configuration.get('sectionB', 'delta', 'jkl'), 'jkl')


### PR DESCRIPTION
Support reading configuration parameters from global, user and local
files.

Fixes #536

Signed-off-by: Simon Rowe <simon.rowe@eu.citrix.com>