### PR TITLE
Makefile.rules: include pins in SPECS and LINKS

### DIFF
--- a/planex/Makefile.rules
+++ b/planex/Makefile.rules
@@ -5,10 +5,10 @@
 
 DIST ?= .el6
 TOPDIR ?= _build
-SPECS ?= $(wildcard SPECS/*.spec)
-LINKS ?= $(wildcard SPECS/*.lnk)
-DEPS = $(TOPDIR)/deps
 PINSDIR ?= PINS
+SPECS ?= $(wildcard $(PINSDIR)/*.spec SPECS/*.spec)
+LINKS ?= $(wildcard $(PINSDIR)/*.pin $(PINSDIR)/*.lnk SPECS/*.lnk)
+DEPS = $(TOPDIR)/deps
 REPOSDIR ?= repos
 RPM_DEFINES ?= --define="_topdir $(TOPDIR)" \
                --define="dist $(DIST)" \


### PR DESCRIPTION
planex-depend now consumes the first link/pin file that matches a spec
file. Extend the default wildcards so that the contents of the PINS
directory are picked up first, if present.

Signed-off-by: Simon Rowe <simon.rowe@eu.citrix.com>