### PR TITLE
clone: fix cloning of plain repositories

### DIFF
--- a/planex/cmd/clone.py
+++ b/planex/cmd/clone.py
@@ -324,3 +324,5 @@ def main(argv=None):
                 else:
                     clone_all(args, pin, nodetached=True)
                     assemble_patchqueue(args, pin)
+            else:
+                clone_all(args, pin)


### PR DESCRIPTION
If there are no patches or patchqueue the source repo was not being
cloned (unless the --clone argument was used).

Signed-off-by: Simon Rowe <simon.rowe@eu.citrix.com>