### PR TITLE
clone: implement cloning of non-git resources

### DIFF
--- a/planex/cmd/clone.py
+++ b/planex/cmd/clone.py
@@ -3,21 +3,29 @@ planex-clone: Checkout sources referred to by a pin file
 """
 from __future__ import print_function
 
-import errno
-from string import Template
 import argparse
-from os import symlink, getcwd
-from os.path import basename, dirname, exists, join, relpath, splitext
+import json
+import logging
+from os import getcwd
+from os.path import exists, join, relpath
+from string import Template
 import subprocess
 import sys
+import tempfile
 import tarfile
-from textwrap import fill
-import json
+
 import git
 
-from planex.cmd.fetch import fetch_source_dispatch
+# pylint: disable=relative-import
+from six.moves.urllib.parse import urlparse, urlunparse, parse_qs, urlencode
+
+from pathlib2 import Path
+
+from planex.cmd.args import common_base_parser
+from planex.cmd.fetch import fetch_url
+from planex.config import Configuration
 from planex.link import Link
-import planex.util as util
+from planex.util import setup_logging
 import planex.spec
 
 
@@ -25,7 +33,9 @@ def parse_args_or_exit(argv=None):
     """
     Parse command line options
     """
-    parser = argparse.ArgumentParser(description='Clone sources')
+    parser = argparse.ArgumentParser(
+        description='Clone package sources',
+        parents=[common_base_parser()])
     parser.add_argument("--jenkins", action="store_true",
                         help="Print Jenkinsfile fragment")
     parser.add_argument("--clone", action="store_true",
@@ -33,58 +43,106 @@ def parse_args_or_exit(argv=None):
     parser.add_argument("--output", "-o",
                         default=join(getcwd(), "clone_sources.json"),
                         help="Choose output name for clone sources JSON file")
-    parser.add_argument(
-        "-r", "--repos", metavar="DIR", default="repos",
-        help='Local path to the repositories')
+    parser.add_argument("-r", "--repos", metavar="DIR", default="repos",
+                        help='Local path to the repositories')
     parser.add_argument("pins", metavar="PINS", nargs="*", help="pin file")
     parser.add_argument("--credentials", metavar="CREDS", default=None,
                         help="Credentials")
     return parser.parse_args(argv)
 
 
-def repo_name(url):
-    """Return the base repository name in url.   This is the name of
-       the directory which would be created by `git clone url`"""
-    return basename(url).rsplit(".git")[0]
+def find_link_pin(package):
+    """
+    From a package name locate the link or pin file
+    """
+    pin_search = Configuration.get('pin', 'search-path',
+                                   default='SPECS').split(':')
+    for suffix in ('.pin', '.lnk'):
+        for subdir in pin_search:
+            path = Path(subdir, package+suffix)
+            if path.exists():
+                return path
+    return None
+
+
+def find_spec(package):
+    """
+    From a package name locate the spec file
+    """
+    spec_search = Configuration.get('spec', 'search-path',
+                                    default='SPECS').split(':')
+    for subdir in spec_search:
+        path = Path(subdir, package+'.spec')
+        if path.exists():
+            return path
+    return None
+
+
+def definitions_for(package):
+    """
+    Return the package name and paths for link/pin and spec files
+    """
+    if package.endswith('.pin') or package.endswith('.lnk'):
+        # link/pin pathname
+        link_pin = Path(package)
+        package = link_pin.stem
+    else:
+        # package name
+        link_pin = find_link_pin(package)
+
+    spec = find_spec(package)
+    if spec is None:
+        sys.exit("No spec file for "+package)
+
+    return package, spec, link_pin
 
 
 CHECKOUT_TEMPLATE = Template("""checkout poll: true,
-         scm:[$$class: 'GitSCM',
-              branches: [[name: '$branch']],
-              extensions: [[$$class: 'RelativeTargetDirectory',
-                            relativeTargetDir: '$checkoutdir'],
-                           [$$class: 'LocalBranch']],
-              userRemoteConfigs: [
-                [credentialsId: '$credentials',
-                 url: '$url']]]
+         scm: [$$class: 'GitSCM',
+               branches: [[name: '$branch']],
+               extensions: [[$$class: 'RelativeTargetDirectory',
+                             relativeTargetDir: '$checkoutdir'],
+                            [$$class: 'LocalBranch']],
+               userRemoteConfigs: [
+                 [credentialsId: '$credentials',
+                  url: '$url']]]
 """)
 
 
-def clone_jenkins_json(filename, url, commitish):
-    """Print JSON file containing repositories to clone"""
+def clone_jenkins_json(package, filename, url, commitish):
+    """
+    Print JSON file containing repositories to clone
+    """
     json_dict = {}
     if exists(filename):
         with open(filename, "r") as clone_sources:
             json_dict.update(json.load(clone_sources))
-    json_dict[repo_name(url)] = {'URL': url, 'commitish': commitish}
+    json_dict[package] = {'URL': url, 'commitish': commitish}
     with open(filename, "w") as clone_sources:
         clone_sources.write(json.dumps(json_dict, indent=2, sort_keys=True))
         print(file=clone_sources)
 
 
-def clone_jenkins_groovy(destination, credentials, url, commitish):
-    """output groovy for backwards compatibility"""
-    destination = join(destination, repo_name(url))
+def clone_jenkins_groovy(package, destination, credentials, url, commitish):
+    """
+    Output Groovy SCM fragment for backwards compatibility
+    """
+    destination = join(destination, package)
     print(CHECKOUT_TEMPLATE.substitute(url=url,
                                        branch=commitish,
                                        checkoutdir=destination,
                                        credentials=credentials))
 
 
-def clone(url, destination, commitish, nodetached=True):
-    """Clone repository"""
-    destination = join(destination, repo_name(url))
-    repo = git.Repo.clone_from(url, destination)
+def clone(url, destination, commitish):
+    """
+    Clone git repository and checkout at commitish
+    """
+
+    if not destination.parent.exists():
+        destination.parent.mkdir(parents=True)
+
+    repo = git.Repo.clone_from(url, str(destination))
     if commitish in repo.remotes['origin'].refs:
         branch_name = commitish
         commit = repo.remotes['origin'].refs[commitish]
@@ -97,247 +155,161 @@ def clone(url, destination, commitish, nodetached=True):
         branch_name = "planex/%s" % commitish[:8]
         commit = repo.rev_parse(commitish)
 
-    # if we are assemblying a patchqueue or a
-    # repatched component we care not being in
-    # detached state, so we commit to a
-    # planex/commitish branch as done previously
-    if nodetached:
-        local_branch = repo.create_head(branch_name, commit)
-        local_branch.checkout()
-    else:
-        repo.git.checkout(commitish)
+    local_branch = repo.create_head(branch_name, commit)
+    local_branch.checkout()
 
     return repo
 
 
-def apply_patchqueue(base_repo, pq_repo, pq_dir):
+def extract(url_str, destination):
     """
-    Apply a patchqueue to a base repository
+    Fetch a non-git resource and create a git repository
     """
-    # Symlink the patchqueue repository into .git/patches
-    link_path = relpath(pq_repo.working_dir, base_repo.git_dir)
-    symlink(link_path, join(base_repo.git_dir, "patches"))
+    archive_file = None
 
-    # Symlink the patchqueue directory to match the base_repo
-    # branch name as guilt expects
-    patchqueue_path = join(base_repo.git_dir, "patches",
-                           base_repo.active_branch.name)
-    branch_path = dirname(base_repo.active_branch.name)
-    util.makedirs(dirname(patchqueue_path))
-    try:
-        symlink(relpath(pq_dir, branch_path), patchqueue_path)
-    except OSError as err:
-        if err.errno == errno.EEXIST:
-            pass
-        else:
-            raise
+    # pylint: disable=no-member
+    destination.mkdir(parents=True)
+    repo = git.Repo.init(str(destination))
 
-    # Create empty guilt status for the branch
-    status = join(patchqueue_path, 'status')
-    open(status, 'w').close()
+    logging.debug("Extracting %s to new git repo", url_str)
+    url = urlparse(url_str)
+    if url.scheme in ('', 'file') and url.netloc == '':
+        # local file
+        archive_path = url.path
+    else:
+        # remote URL
+        archive_file = tempfile.NamedTemporaryFile(prefix='clone-')
+        archive_path = archive_file.name
 
-    # Push patchqueue
-    # `guilt push --all` fails with a non-zero error code if the patchqueue
-    # is empty; this cannot be distinguished from a patch failing to apply,
-    # so skip trying to push if the patchqueue is empty.
-    patches = subprocess.check_output(['guilt', 'unapplied'],
+        query = parse_qs(url.query)
+        if 'prefix' in query:
+            # strip off the directory prefix
+            del query['prefix']
+            query_str = urlencode(query, doseq=True)
+            url_str = urlunparse((url.scheme, url.netloc, url.path, url.params,
+                                  query_str, url.fragment))
+            url = urlparse(url_str)
+
+        fetch_url(url, archive_path, 5)
+
+    # extract the archive
+    tara = tarfile.open(archive_path)
+    tara.extractall(str(destination))
+    tara.close()
+
+    if archive_file:
+        # delete temp file
+        archive_file.close()
+
+    index = repo.index
+    index.add(repo.untracked_files)
+    index.commit("Repo generated by planex-clone")
+
+    return repo
+
+
+def clone_resource(resource, destination):
+    """
+    Clone a resource as a git repository
+    """
+    if resource.is_repo:
+        logging.info("Clone and checkout %s@%s into %s", resource.url,
+                     resource.commitish, destination)
+        repo = clone(resource.url, destination, resource.commitish)
+    else:
+        logging.info("Fetch and extract %s into %s", resource.url, destination)
+        repo = extract(resource.url, destination)
+
+    return repo
+
+
+def clone_jenkins(args, spec):
+    """
+    Generate either a JSON object or a Groovy fragment that describes
+    the git-based resources of a package
+    """
+    for resource in spec.resources():
+        if resource.is_repo:
+            package = resource.basename.rsplit(".git")[0]
+            url = resource.url
+            commitish = resource.commitish
+
+            if args.credentials:
+                # output Groovy fragment
+                print('echo "Cloning %s#%s"' % (url, commitish))
+                clone_jenkins_groovy(package, args.repos, args.credentials,
+                                     url, commitish)
+            else:
+                # output JSON object
+                clone_jenkins_json(package, args.output, url, commitish)
+
+
+def clone_all_git(args, spec):
+    """
+    Clone all git repositories for a package
+    """
+    for resource in spec.resources():
+        if resource.is_repo:
+            # remove trailing '.git'
+            destination = Path(args.repos, resource.basename[:-4])
+            clone_resource(resource, destination)
+
+
+def clone_all_fetchable(args, package, spec):
+    """
+    Clone all remote resources for a package
+    """
+    for resource in spec.resources():
+        if resource.is_fetchable:
+            if resource.is_repo:
+                # remove trailing '.git'
+                destination = Path(args.repos, resource.basename[:-4])
+            else:
+                destination = Path(args.repos, package)
+            clone_resource(resource, destination)
+
+
+def apply_patchqueue(base_repo, pq_repo, prefix):
+    """
+    Link and then apply a patchqueue repository to a source repository
+    """
+    status_path = Path(pq_repo.working_dir, prefix, 'status')
+    patches_link = Path(base_repo.git_dir, 'patches',
+                        base_repo.active_branch.name)
+
+    # make the directory tree for the patches within the base repo
+    # pylint: disable=no-member
+    patches_link.parent.mkdir(parents=True)
+
+    # link the patchqueue directory for the base repo branch
+    rel_path = relpath(str(status_path.parent), str(patches_link.parent))
+    patches_link.symlink_to(rel_path)
+
+    # create an empty status file
+    with status_path.open('w'):
+        pass
+
+    patches = subprocess.check_output(['guilt', 'series'],
                                       cwd=base_repo.working_dir)
     if patches:
         subprocess.check_call(['guilt', 'push', '--all'],
                               cwd=base_repo.working_dir)
 
-# pylint: disable=too-many-locals
 
-
-def clone_all(args, pin, nodetached=False):
+def clone_with_patchq(package, repos_base, base_res, pq_res):
     """
-    Clone all the resources described by a pin.
+    Given a source and patchqueue resource clone repos and apply the patchqueue
     """
-    # The following assumes that the pin file does not use any
-    # rpm macro in its fields. We can enable them by using
-    # planex.spec.load and the right RPM_DEFINES but it is more
-    # error prone and should probably be done only if we see
-    # that it is an essential feature.
-    gathered = ([source for _, source in pin.sources.items()
-                 if source.get('commitish', False)] +
-                [archive for _, archive in pin.archives.items()
-                 if archive.get('commitish', False)] +
-                [pq for _, pq in pin.patchqueue_sources.items()
-                 if pq.get('commitish', False)])
-
-    # Prevent double-cloning of a repository
-    gathered = set((gath['URL'], gath['commitish'])
-                   for gath in gathered)
-
-    if gathered:
-        print('\nClones for %s' % basename(pin.linkpath))
-
-    # this is suboptimal but the sets are very small
-    if any(commitish1 != commitish2
-           for (url1, commitish1) in gathered
-           for (url2, commitish2) in gathered
-           if url1 == url2):
-        sys.exit("error: cloning two git repositories with the same "
-                 "name but different commitish is not supported.")
-
-    for url, commitish in gathered:
-        print('Cloning %s#%s' % (url, commitish))
-        util.makedirs(args.repos)
-        try:
-            clone(url, args.repos, commitish, nodetached)
-        except git.GitCommandError as gce:
-            print(gce.stderr)
-
-
-def clone_jenkins(args, pin):
-    """
-    Generate either a JSON object or a Groovy fragment that describes
-    the terminal resource of a pin.
-    """
-    for resource in (pin.patchqueue_sources, pin.archives, pin.sources):
-        if resource:
-            url = resource.values()[0]['URL']
-            commitish = resource.values()[0]['commitish']
-
-            if args.credentials:
-                # output Groovy fragment
-                print('echo "Cloning %s#%s"' % (url, commitish))
-                clone_jenkins_groovy(args.repos, args.credentials, url,
-                                     commitish)
-            else:
-                # output JSON object
-                clone_jenkins_json(args.output, url, commitish)
-            break
-
-
-def assemble_patchqueue(args, pin):
-    """
-    Assemble patchqueues using Source0 and PatchQueue0 using
-    the active branches in the cloned sources.
-    """
-    sources = {
-        key: src['URL']
-        for key, src in pin.sources.items()
-        if src.get('commitish', False)
-    }
-    patchqueues = {
-        key: (pq['URL'], dirname(pq['prefix']))
-        for key, pq in pin.patchqueue_sources.items()
-        if pq.get('commitish', False)
-    }
-
-    if 'Source0' not in sources:
-        sys.exit("error: planex-clone requires Source0 to point to "
-                 "a git repository.")
-    if 'PatchQueue0' not in patchqueues:
-        sys.exit("error: planex-clone requires PatchQueue0 to point "
-                 "to a git repository.")
-
-    if len(patchqueues.keys()) > 1:
-        sys.exit(
-            "error: planex-clone does not support the cloning and "
-            "assembly of multiple sources and patchqueues, currently "
-            "this case needs to be handled manually.")
-    try:
-        src_url = sources['Source0']
-        pq_url, pq_prefix = patchqueues['PatchQueue0']
-        src_repo = git.Repo(join(args.repos, repo_name(src_url)))
-        pq_repo = git.Repo(join(args.repos, repo_name(pq_url)))
-        apply_patchqueue(src_repo, pq_repo, pq_prefix)
-        print(fill(
-            "By default the PIN file will instruct `planex` to "
-            "`git archive` the source repository and the patchqueue "
-            "repository at the commitish specified in the pin file, "
-            "then assemble the patchqueue when building the RPM.\n"
-            "If you want to build using the HEAD of the source repository, "
-            "where you have all your ongoing modifications applied, you "
-            "can edit the pin file as follows: \n"
-            "\t- delete the `PatchQueue0` section, and\n"
-            "\t- set the correct commitish for `Source0` (usually the name "
-            "of the active branch)."
-        ))
-    except git.GitCommandError as gce:
-        print(gce.stderr)
-
-
-def assemble_repatched(args, specpath, defines, pin):
-    """
-    Assemble an upstream centos package and apply the upstream patchqueue,
-    then apply the local patchqueue.
-    """
-    sources = {
-        key: (src['URL'], bool(src.get("commitish", False)))
-        for key, src in pin.sources.items()
-    }
-    archives = {
-        key: (arc['URL'], dirname(arc['prefix']),
-              bool(arc.get("commitish", False)))
-        for key, arc in pin.archives.items()
-    }
-    patchqueues = {
-        key: (pq['URL'], dirname(pq['prefix']))
-        for key, pq in pin.patchqueue_sources.items()
-        if pq.get('commitish', False)
-    }
-
-    if 'Source0' not in sources:
-        sys.exit("error: planex-clone requires Source0 to be specified.")
-    if 'Archive0' not in archives:
-        sys.exit("error: planex-clone requires Archive0 to be specified.")
-    if 'PatchQueue0' not in patchqueues:
-        sys.exit("error: planex-clone requires PatchQueue0 to point "
-                 "to a git repository.")
-
-    spec = planex.spec.load(specpath, link=pin,
-                            check_package_name=True,
-                            defines=defines)
-
-    for source in (sources['Source0'], archives['Archive0']):
-        if not source[1]:
-            try:
-                resource = spec.resource(source[0])
-            except KeyError as exn:
-                sys.exit("error: No source corresponding to %s" % exn)
-            fetch_source_dispatch(resource, retries=1)
-
-    # If the source is a tarball, we need to unpack it and
-    # init it as a git repository
-    if not sources['Source0'][1]:
-        resource = spec.resource(sources['Source0'][0])
-        reponame, _ = splitext(basename(specpath))
-        repopath = join(args.repos, reponame)
-        if not tarfile.is_tarfile(resource.path):
-            sys.exit("error: invalid source at {}".format(resource.path))
-        with tarfile.open(resource.path) as tar:
-            tar.extractall(path=repopath)
-        src_repo = git.Repo.init(repopath)
-        src_repo.index.add([['*']])
-        src_repo.index.commit("base")
+    if base_res.is_repo:
+        # remove trailing '.git'
+        base_dest = Path(repos_base, base_res.basename.rsplit(".git")[0])
     else:
-        repopath = join(args.repos, repo_name(sources['Source0'][0]))
-        src_repo = git.Repo(repopath)
+        base_dest = Path(repos_base, package)
+    base_repo = clone_resource(base_res, base_dest)
 
-    patches = sorted(
-        ((kind, resource)
-         for kind, resource in spec.resources_dict().items()
-         if kind.startswith("Patch") and "Queue" not in kind),
-        key=lambda kv: int(kv[0][5:])
-    )
-    patches = [basename(resource.path) for _, resource in patches]
-
-    for patch in patches:
-        print("Applying archive patch..{}".format(patch))
-        patchpath = join("..",
-                         repo_name(archives['Archive0'][0]),
-                         archives['Archive0'][1],
-                         patch)
-        src_repo.git.apply('-p1', '--index', patchpath)
-        src_repo.index.commit(basename(patch))
-        print("Patch applied.")
-
-    pq_name, pq_prefix = patchqueues['PatchQueue0']
-    pq_repo = git.Repo(join(args.repos, repo_name(pq_name)))
-    apply_patchqueue(src_repo, pq_repo, pq_prefix)
+    pq_dest = Path(str(base_dest)+'.pg')
+    pq_repo = clone_resource(pq_res, pq_dest)
+    apply_patchqueue(base_repo, pq_repo, pq_res.prefix)
 
 
 def main(argv=None):
@@ -345,27 +317,36 @@ def main(argv=None):
     Entry point
     """
     args = parse_args_or_exit(argv)
+    setup_logging(args)
 
-    for pinpath in args.pins:
-        pin = Link(pinpath)
+    for pin in args.pins:
+        package, spec_path, link_pin_path = definitions_for(pin)
+
+        link_pin = None
+        if link_pin_path:
+            logging.debug("Reading link/pin file %s", link_pin_path)
+            link_pin = Link(str(link_pin_path))
+        logging.debug("Reading spec file %s", spec_path)
+        spec = planex.spec.load(str(spec_path), link=link_pin,
+                                check_package_name=False)
 
         if args.clone:
-            clone_all(args, pin)
-        if args.jenkins:
-            clone_jenkins(args, pin)
+            # just clone git resources
+            clone_all_git(args, spec)
+        elif args.jenkins:
+            # generate Jenkins information
+            clone_jenkins(args, spec)
         else:
-            if "PatchQueue0" in pin.patchqueue_sources:
-                if "Archive0" in pin.archives:
-                    specname, _ = splitext(basename(pinpath))
-                    specpath = "SPECS/{}.spec".format(specname)
-                    defines = [
-                        ("_topdir", "_build"),
-                        ("_sourcedir", "%_topdir/SOURCES/%name")
-                    ]
-                    clone_all(args, pin, nodetached=True)
-                    assemble_repatched(args, specpath, defines, pin)
+            resources = spec.resources_dict()
+            if "PatchQueue0" in resources:
+                if "Archive0" in resources:
+                    raise NotImplementedError("Cloning patched "
+                                              "components not implemented")
                 else:
-                    clone_all(args, pin, nodetached=True)
-                    assemble_patchqueue(args, pin)
+                    # component with patchqueue
+                    clone_with_patchq(package, args.repos,
+                                      resources['Source0'],
+                                      resources['PatchQueue0'])
             else:
-                clone_all(args, pin)
+                # clone all fetchable resources
+                clone_all_fetchable(args, package, spec)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 argcomplete
 argparse
 gitpython
+pathlib2
 requests


### PR DESCRIPTION
Requiring a pin to contain only repository-backed resources has an
impact on the repositories cloned and monitored by the CI
system. Support, for example, having a https:// URL for the base
repository with an ssh:// URL for a patchqueue.

Signed-off-by: Simon Rowe <simon.rowe@eu.citrix.com>