### PR TITLE
Clean up more things

### DIFF
--- a/planex/Makefile.rules
+++ b/planex/Makefile.rules
@@ -76,9 +76,15 @@ srpms: $(SRPMS)
 
 
 .PHONY: clean
-clean:
-	rm -rf $(TOPDIR)
+clean:	scrub
+	rm -rf $(TOPDIR) $(MOCK_CONFIGDIR)
+	rm -f MANIFESTS RPMS
 
+.PHONY: scrub
+scrub:
+ifneq ($(wildcard $(MOCK_CONFIGDIR)/$(MOCK_ROOT).cfg),)
+	mock --configdir=$(MOCK_CONFIGDIR) -r $(MOCK_ROOT) --scrub=all
+endif
 
 ############################################################################
 # Source download rules


### PR DESCRIPTION
Now that mock configurations are being generated on the fly, the clean
target needs to remove them, to avoid problems when switching
configurations but having old configs lying around.

In addition, when removing them we should be sure to scrub any extant
mock caches and chroots as repository metadata may persist there and
cause problems later.

Since MANIFESTS and RPMS are symbolic links into a location we've just
removed, clean them up also.