### PR TITLE
Correct error path on RequestException

### DIFF
--- a/planex/cmd/fetch.py
+++ b/planex/cmd/fetch.py
@@ -161,7 +161,7 @@ def fetch_url(url, source, retries):
     except requests.RequestException as exn:
         # Download failed
         sys.exit("%s: Failed to fetch %s: %s" %
-                 (sys.argv[0], urlunparse(url), exn.args[1]))
+                 (sys.argv[0], urlunparse(url), str(exn)))
 
     except IOError as exn:
         # IO error saving source file


### PR DESCRIPTION
The length of the args array when a RequestException occurs is not
known. If sticking to descriptors inherited from BaseException, it would
be better to use 'message' to avoid an exception while handling the
exception.