### PR TITLE
CP-31484 Honor yum repository priorities in mock builds

### DIFF
--- a/tests/test_createmockconfig.py
+++ b/tests/test_createmockconfig.py
@@ -39,6 +39,7 @@ class MockRepo(object):
     def __init__(self, repoid="", enabled=True):
         self.id = repoid
         self.enabled = enabled
+        self.priority = 99
 
 
 class MockYumBaseRepos(object):


### PR DESCRIPTION
Since repository priorities are needed to get packages from the
right place, in order for mock builds to work correctly we need to put
the priority information into the mock configuration we generate.

We also need to turn on the priority plugin inside the mock chroot, or
this will not do any good.

While doing this, sort the entries in the mock config by priority and
then by name so that it's easy to grep them out in the right order
later.