### PR TITLE
do not try to lookup SHA1 from tags in planex-pin

### DIFF
--- a/planex/cmd/pin.py
+++ b/planex/cmd/pin.py
@@ -58,7 +58,7 @@ def populate_pinfile(pinfile, resources):
             commitish = source.commitish
             prefix = source.prefix
         else:
-            repo = Repository(source.url)
+            repo = Repository(source.url, skipPopulateHash=True)
             commitish = repo.commitish_tag_or_branch()
             url = repo.repository_url()
             prefix = None

--- a/planex/repository.py
+++ b/planex/repository.py
@@ -21,7 +21,7 @@ class Repository(object):
 
     # pylint: disable=R0902
 
-    def __init__(self, url):
+    def __init__(self, url, skipPopulateHash=False):
         self.url = urlparse(url)
         self.clone_url = None
         self._query_url = None
@@ -32,7 +32,7 @@ class Repository(object):
         self.sha1 = None
         self.archive_at = None
         self.repomgr = self.repomanager_from_netloc()
-        if self.repomgr in self.parsers:
+        if self.repomgr in self.parsers and not skipPopulateHash:
             self.parsers[self.repomgr](self)
             self._populate_sha1()
 


### PR DESCRIPTION
The tag may not be a tag at all, but a commit hash, in which case the
bitbucket lookup would fail.

We do not need to perform the sha1 lookup for planex-pin, so avoid it instead of throwing a 404.

Signed-off-by: Edwin Török <edvin.torok@citrix.com>