### PR TITLE
CA-318284 Wildcard expansion fails internally

### DIFF
--- a/planex/cmd/clone.py
+++ b/planex/cmd/clone.py
@@ -90,6 +90,12 @@ def definitions_for(package):
     """
     Return the package name and paths for link/pin and spec files
     """
+    # *.pin gets passed down
+    # and wildcard expansion has not occured
+    if "*" in package:
+        print("No pin files found")
+        sys.exit(0)
+
     if package.endswith('.pin') or package.endswith('.lnk'):
         # link/pin pathname
         link_pin = Path(package)

--- a/tests/test_createmockconfig.py
+++ b/tests/test_createmockconfig.py
@@ -36,8 +36,9 @@ class MockYumBase(object):
 class MockRepo(object):
     """mock class for repo"""
     # pylint: disable=R0903,C0103
-    def __init__(self, repoid="", enabled=True):
+    def __init__(self, name="", repoid="", enabled=True):
         self.id = repoid
+        self.name = name
         self.enabled = enabled
         self.priority = 99
 
@@ -46,9 +47,11 @@ class MockYumBaseRepos(object):
     """mock class for yum.YumBase().repos"""
     # pylint: disable=C0103
     def __init__(self):
-        self.repos = [MockRepo("base"), MockRepo("extras"),
-                      MockRepo("updates"), MockRepo("TestAAA", False),
-                      MockRepo("TestBBB", False)]
+        self.repos = [MockRepo("base", "base"),
+                      MockRepo("extras", "extras"),
+                      MockRepo("updates", "updates"),
+                      MockRepo("TestAAA", "TestAAA", False),
+                      MockRepo("TestBBB", "TestBBB", False)]
 
     def listEnabled(self):
         """mock function for yum.YumBase().repos.listEnabled"""


### PR DESCRIPTION
*.pin will get passed down to planex-clone if nothing is expanded on the
terminal, just check for wildcards in filenames and exit quietly.